### PR TITLE
Feature/terraform demo env

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# CODEOWNERS — automatic reviewer assignment based on file paths.
+# Syntax: <pattern> <GitHub user or team>
+#
+# Rules:
+# - Patterns are matched from bottom to top (last match wins)
+# - At least one owner must approve before a PR can be merged (with branch protection enabled)
+# - Use @org/team-name for team ownership, @username for individual ownership
+#
+# Replace the placeholder handles below with your actual GitHub usernames/teams.
+
+# Default owner for everything not matched below
+*                                   @your-org/platform-team
+
+# Production environment — requires senior engineer sign-off
+environments/prod/**                @your-org/platform-leads
+
+# All CI/CD pipeline changes — any pipeline engineer can approve
+.github/workflows/**                @your-org/platform-team
+
+# IAM changes require security team review
+modules/iam/**                      @your-org/security-team
+modules/kms/**                      @your-org/security-team
+
+# Network changes require network engineer review
+modules/networking/**               @your-org/platform-team
+
+# Documentation changes — any team member
+*.md                                @your-org/platform-team
+CONTRIBUTING.md                     @your-org/platform-team

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- 2-3 bullet points describing what changed and why -->
+-
+-
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / module
+- [ ] Enhancement to existing module
+- [ ] Security hardening
+- [ ] Documentation
+- [ ] CI/CD pipeline change
+- [ ] Refactor (no behaviour change)
+
+## Changes
+
+<!-- List the modules, environments, or files changed -->
+
+## Pre-merge checklist
+
+### Code quality
+- [ ] `make fmt` — all files formatted (`terraform fmt -recursive`)
+- [ ] `make validate ENV=dev` — no validation errors
+- [ ] `make plan ENV=dev` — plan reviewed; no unexpected resource recreation
+- [ ] `make lint ENV=dev` — TFLint passes
+- [ ] `make security-scan ENV=dev` — Checkov passes (or suppressions documented with justification)
+- [ ] `make test` — all module unit tests pass
+
+### Infrastructure safety
+- [ ] Plan output reviewed for `forces replacement` — any recreation is intentional and acceptable
+- [ ] No sensitive values (account IDs, secrets, ARNs) hardcoded in `.tf` files
+- [ ] `force_destroy`, `prevent_destroy`, `deletion_protection` set correctly for the target environment
+
+### Documentation
+- [ ] Module README updated if inputs, outputs, or behaviour changed
+- [ ] CHANGELOG.md updated under `## [Unreleased]`
+- [ ] New modules include a `README.md`, `versions.tf`, and at least one `.tftest.hcl` file
+
+## Notes for reviewers
+
+<!-- Anything that needs special attention, context on decisions made, or known trade-offs -->
+
+## Related issues / PRs
+
+<!-- Closes #<issue> -->

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,3 +41,4 @@ jobs:
       require_approval: false
     secrets:
       aws_role_arn: ${{ secrets.DEV_DEPLOY_ROLE }}
+      infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,11 +33,7 @@ jobs:
     uses: ./.github/workflows/terraform-deploy.yml
     with:
       environment: dev
-      run_apply: |
-        ${{
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dev-')) ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
-        }}
+      run_apply: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dev-')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply') }}
       require_approval: false
     secrets:
       aws_role_arn: ${{ secrets.DEV_DEPLOY_ROLE }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -38,3 +38,4 @@ jobs:
     secrets:
       aws_role_arn: ${{ secrets.DEV_DEPLOY_ROLE }}
       infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}
+      aws_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,4 +1,4 @@
-name: Dev Terraform CI
+name: Dev
 
 on:
   pull_request:
@@ -21,205 +21,23 @@ on:
           - plan
           - apply
 
-# Prevent concurrent deploys to the same environment.
-# A new run waits for any in-progress run to finish before starting.
 concurrency:
   group: terraform-dev
   cancel-in-progress: false
 
-# Default to read-only. Individual jobs elevate only what they need.
 permissions:
   contents: read
 
-env:
-  AWS_ROLE_TO_ASSUME: ${{ secrets.DEPLOY_ROLE }}
-  AWS_REGION: "us-west-2"
-  ENVIRONMENT: dev
-  TF_VERSION: "1.7.5"
-  CHECKOV_VERSION: "3.2.73"
-
 jobs:
-  terraform:
-    name: Terraform Validate & Plan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write       # OIDC token for AWS credential exchange
-      pull-requests: write  # Post plan output as a PR comment
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-plan
-
-      - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Terraform Format Check
-        run: terraform fmt -check -recursive
-
-      - name: Terraform Init
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
-            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
-
-      - name: Terraform Validate
-        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} validate
-
-      - name: Terraform Plan
-        id: plan
-        run: |
-          set -o pipefail
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
-            -no-color \
-            -out=tfplan \
-            2>&1 | tee plan_output.txt
-
-      - name: Upload plan artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-tfplan
-          path: environments/${{ env.ENVIRONMENT }}/tfplan
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Comment PR with plan output
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const fs = require('fs');
-            const outputPath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
-            const raw = fs.readFileSync(outputPath, 'utf8');
-            const body = raw.length > 65000
-              ? raw.substring(0, 65000) + '\n\n...[truncated — see Actions logs for full output]'
-              : raw;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## Dev — Terraform Plan\n\`\`\`\n${body}\n\`\`\``
-            });
-
-  checkov-scan:
-    name: Checkov Security Scan
-    needs: terraform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Setup Python
-        uses: actions/setup-python@v4.7.1
-        with:
-          python-version: '3.11'
-
-      - name: Install Checkov (pinned)
-        run: pip install checkov==${{ env.CHECKOV_VERSION }}
-
-      - name: Run Checkov
-        run: |
-          checkov \
-            --directory environments/${{ env.ENVIRONMENT }} \
-            --skip-check CKV_TF_1
-          # CKV_TF_1: local monorepo modules cannot be version-pinned by source path.
-          # The git tag is the version boundary. Registry modules must still be pinned.
-
-  tflint-check:
-    name: TFLint Check
-    needs: terraform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write  # Needed to resolve AWS data sources during lint
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-lint
-
-      - name: Install TFLint
-        run: |
-          curl -sL \
-            https://github.com/terraform-linters/tflint/releases/download/v0.50.3/tflint_linux_amd64.zip \
-            -o tflint.zip
-          unzip tflint.zip
-          sudo mv tflint /usr/local/bin/
-
-      - name: TFLint Init
-        run: tflint --init
-
-      - name: Run TFLint
-        run: tflint --chdir=environments/${{ env.ENVIRONMENT }}
-
-  apply:
-    name: Apply Terraform
-    needs: [checkov-scan, tflint-check]
-    runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dev-')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
-    environment: dev
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-apply
-
-      - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Terraform Init
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
-            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
-
-      # Generate a fresh plan immediately before apply.
-      # The PR-stage plan can be stale: infrastructure state may have changed
-      # between PR merge and the deployment tag being pushed.
-      - name: Terraform Plan (pre-apply)
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
-            -no-color \
-            -out=tfplan
-
-      - name: Terraform Apply
-        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} apply tfplan
-
-      - name: Capture outputs
-        if: always()
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} output -no-color \
-            > environments/${{ env.ENVIRONMENT }}/apply_output.txt 2>&1 || true
-
-      - name: Upload apply artefact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-apply-output
-          path: environments/${{ env.ENVIRONMENT }}/apply_output.txt
-          retention-days: 30
+  deploy:
+    uses: ./.github/workflows/terraform-deploy.yml
+    with:
+      environment: dev
+      run_apply: |
+        ${{
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dev-')) ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+        }}
+      require_approval: false
+    secrets:
+      aws_role_arn: ${{ secrets.DEV_DEPLOY_ROLE }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,174 +10,216 @@ on:
   push:
     tags:
       - 'dev-*'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        default: 'plan'
+        type: choice
+        options:
+          - plan
+          - apply
 
+# Prevent concurrent deploys to the same environment.
+# A new run waits for any in-progress run to finish before starting.
+concurrency:
+  group: terraform-dev
+  cancel-in-progress: false
+
+# Default to read-only. Individual jobs elevate only what they need.
 permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  actions: write
-  issues: write
+  contents: read
 
 env:
   AWS_ROLE_TO_ASSUME: ${{ secrets.DEPLOY_ROLE }}
   AWS_REGION: "us-west-2"
-  SECRET_KEY: ${{ secrets.GITHUB_TOKEN }}
   ENVIRONMENT: dev
+  TF_VERSION: "1.7.5"
+  CHECKOV_VERSION: "3.2.73"
 
 jobs:
   terraform:
     name: Terraform Validate & Plan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write       # OIDC token for AWS credential exchange
+      pull-requests: write  # Post plan output as a PR comment
     steps:
-      - uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-session
+          role-session-name: github-actions-dev-plan
 
-      - name: Setup Terraform
+      - name: Setup Terraform ${{ env.TF_VERSION }}
         uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
 
-      - name: Terraform Format
+      - name: Terraform Format Check
         run: terraform fmt -check -recursive
 
       - name: Terraform Init
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
 
       - name: Terraform Validate
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform validate
+        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} validate
 
       - name: Terraform Plan
-        id: terraform-plan
-        if: github.event_name == 'pull_request'
+        id: plan
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform plan -no-color 2>&1 | tee plan_output.txt
+          set -o pipefail
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -no-color \
+            -out=tfplan \
+            2>&1 | tee plan_output.txt
 
-      - name: Comment PR with Plan Result
+      - name: Upload plan artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-tfplan
+          path: environments/${{ env.ENVIRONMENT }}/tfplan
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Comment PR with plan output
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6.4.1
         with:
           script: |
             const fs = require('fs');
-            const outputFilePath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
-            const output = fs.readFileSync(outputFilePath, 'utf8');
-            const truncated = output.length > 65000
-              ? output.substring(0, 65000) + '\n\n... [truncated — see Actions logs for full output]'
-              : output;
+            const outputPath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
+            const raw = fs.readFileSync(outputPath, 'utf8');
+            const body = raw.length > 65000
+              ? raw.substring(0, 65000) + '\n\n...[truncated — see Actions logs for full output]'
+              : raw;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Dev Terraform Plan\n\`\`\`\n${truncated}\n\`\`\``
+              body: `## Dev — Terraform Plan\n\`\`\`\n${body}\n\`\`\``
             });
 
   checkov-scan:
     name: Checkov Security Scan
     needs: terraform
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v4.7.1
         with:
           python-version: '3.11'
 
-      - name: Install Checkov
-        run: pip install checkov
+      - name: Install Checkov (pinned)
+        run: pip install checkov==${{ env.CHECKOV_VERSION }}
 
       - name: Run Checkov
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          # CKV_TF_1: skipped — this repo uses local module paths (monorepo pattern).
-          # Local sources cannot be version-pinned; the git tag controls the version.
-          checkov -d . --download-external-modules true --skip-check CKV_TF_1
+          checkov \
+            --directory environments/${{ env.ENVIRONMENT }} \
+            --skip-check CKV_TF_1
+          # CKV_TF_1: local monorepo modules cannot be version-pinned by source path.
+          # The git tag is the version boundary. Registry modules must still be pinned.
 
   tflint-check:
     name: TFLint Check
     needs: terraform
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Needed to resolve AWS data sources during lint
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-session
+          role-session-name: github-actions-dev-lint
 
       - name: Install TFLint
         run: |
-          wget https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip
-          unzip tflint_linux_amd64.zip
+          curl -sL \
+            https://github.com/terraform-linters/tflint/releases/download/v0.50.3/tflint_linux_amd64.zip \
+            -o tflint.zip
+          unzip tflint.zip
           sudo mv tflint /usr/local/bin/
 
-      - name: Install TFLint AWS Plugin
-        run: |
-          mkdir -p ~/.tflint.d/plugins
-          wget https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v0.27.0/tflint-ruleset-aws_linux_amd64.zip
-          unzip tflint-ruleset-aws_linux_amd64.zip -d ~/.tflint.d/plugins/
-
-      - name: Initialize TFLint
+      - name: TFLint Init
         run: tflint --init
 
       - name: Run TFLint
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          tflint
+        run: tflint --chdir=environments/${{ env.ENVIRONMENT }}
 
   apply:
     name: Apply Terraform
     needs: [checkov-scan, tflint-check]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dev-')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dev-')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
     environment: dev
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-session
+          role-session-name: github-actions-dev-apply
 
-      - name: Setup Terraform
+      - name: Setup Terraform ${{ env.TF_VERSION }}
         uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
 
       - name: Terraform Init
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
+      # Generate a fresh plan immediately before apply.
+      # The PR-stage plan can be stale: infrastructure state may have changed
+      # between PR merge and the deployment tag being pushed.
+      - name: Terraform Plan (pre-apply)
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -no-color \
+            -out=tfplan
 
       - name: Terraform Apply
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform apply -auto-approve 2>&1 | tee apply_output.txt
-          if grep -q "Error:" apply_output.txt; then
-            echo "Terraform apply failed. Check the logs for details."
-            exit 1
-          fi
+        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} apply tfplan
 
-      - name: Upload apply output
+      - name: Capture outputs
         if: always()
-        uses: actions/upload-artifact@v3
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} output -no-color \
+            > environments/${{ env.ENVIRONMENT }}/apply_output.txt 2>&1 || true
+
+      - name: Upload apply artefact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: dev-apply-output
-          path: environments/dev/apply_output.txt
+          path: environments/${{ env.ENVIRONMENT }}/apply_output.txt
+          retention-days: 30

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -100,6 +100,8 @@ jobs:
       - name: Run Checkov
         run: |
           cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
+          # CKV_TF_1: skipped — this repo uses local module paths (monorepo pattern).
+          # Local sources cannot be version-pinned; the git tag controls the version.
           checkov -d . --download-external-modules true --skip-check CKV_TF_1
 
   tflint-check:

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -54,6 +54,7 @@ jobs:
       issues: write  # Open a GitHub issue if drift is detected
     env:
       ENVIRONMENT: dev
+      TF_VAR_account_id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.0
@@ -138,6 +139,7 @@ jobs:
       issues: write
     env:
       ENVIRONMENT: staging
+      TF_VAR_account_id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.0
@@ -217,6 +219,7 @@ jobs:
       issues: write
     env:
       ENVIRONMENT: prod
+      TF_VAR_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.0

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -1,0 +1,284 @@
+name: Drift Detection
+
+# Run a terraform plan against all environments on a schedule and on demand.
+# If the plan shows any diff, the job fails — indicating that the live
+# infrastructure has drifted from the Terraform configuration.
+#
+# Common causes of drift:
+#   - Manual changes made via the AWS Console or CLI
+#   - AWS auto-scaling adjusting capacity (expected — use ignore_changes)
+#   - Auto-applied AWS-managed updates (e.g. security group rules added by services)
+#
+# When drift is detected, the plan output is uploaded as an artefact and a
+# GitHub issue is opened so the team can investigate and reconcile.
+
+on:
+  schedule:
+    # Run at 06:00 UTC every day (before the business day starts)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to check (leave blank for all)'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - dev
+          - staging
+          - prod
+
+concurrency:
+  group: drift-detection
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: "us-west-2"
+  TF_VERSION: "1.7.5"
+
+jobs:
+  drift-dev:
+    name: Drift Check — dev
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.environment == 'all' ||
+      github.event.inputs.environment == 'dev'
+    permissions:
+      contents: read
+      id-token: write
+      issues: write  # Open a GitHub issue if drift is detected
+    env:
+      ENVIRONMENT: dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-actions-drift-dev
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
+      - name: Terraform Plan (drift check)
+        id: plan
+        run: |
+          set -o pipefail
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -detailed-exitcode \
+            -no-color \
+            2>&1 | tee plan_output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        # Exit codes: 0 = no changes, 1 = error, 2 = changes detected (drift)
+        continue-on-error: true
+
+      - name: Upload drift report
+        if: steps.plan.outputs.exit_code == '2'
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-dev-${{ github.run_id }}
+          path: plan_output.txt
+          retention-days: 30
+
+      - name: Open issue on drift detected
+        if: steps.plan.outputs.exit_code == '2'
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('plan_output.txt', 'utf8');
+            const body = plan.length > 10000
+              ? plan.substring(0, 10000) + '\n\n...[truncated — download the full artefact from the workflow run]'
+              : plan;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Drift] Infrastructure drift detected in dev (${new Date().toISOString().split('T')[0]})`,
+              labels: ['drift', 'infrastructure'],
+              body: `## Drift Detected in \`dev\`\n\nA scheduled drift check found that the live infrastructure differs from the Terraform configuration.\n\n**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n### Plan output\n\`\`\`\n${body}\n\`\`\`\n\n### Resolution\n1. Review the plan output above\n2. If the drift is expected (e.g. autoscaling), add \`ignore_changes\` to the relevant resource\n3. If the drift is unexpected, investigate who made the manual change and re-apply Terraform to reconcile`
+            });
+
+      - name: Fail on drift
+        if: steps.plan.outputs.exit_code == '2'
+        run: |
+          echo "Drift detected in dev environment. See uploaded artefact and opened issue."
+          exit 1
+
+      - name: Fail on plan error
+        if: steps.plan.outputs.exit_code == '1'
+        run: |
+          echo "Terraform plan failed with an error."
+          exit 1
+
+  drift-staging:
+    name: Drift Check — staging
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.environment == 'all' ||
+      github.event.inputs.environment == 'staging'
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    env:
+      ENVIRONMENT: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.STAGING_DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-actions-drift-staging
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
+      - name: Terraform Plan (drift check)
+        id: plan
+        run: |
+          set -o pipefail
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -detailed-exitcode \
+            -no-color \
+            2>&1 | tee plan_output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Upload drift report
+        if: steps.plan.outputs.exit_code == '2'
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-staging-${{ github.run_id }}
+          path: plan_output.txt
+          retention-days: 30
+
+      - name: Open issue on drift detected
+        if: steps.plan.outputs.exit_code == '2'
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('plan_output.txt', 'utf8');
+            const body = plan.length > 10000
+              ? plan.substring(0, 10000) + '\n\n...[truncated]'
+              : plan;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Drift] Infrastructure drift detected in staging (${new Date().toISOString().split('T')[0]})`,
+              labels: ['drift', 'infrastructure'],
+              body: `## Drift Detected in \`staging\`\n\n**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n### Plan output\n\`\`\`\n${body}\n\`\`\``
+            });
+
+      - name: Fail on drift
+        if: steps.plan.outputs.exit_code == '2'
+        run: exit 1
+
+      - name: Fail on plan error
+        if: steps.plan.outputs.exit_code == '1'
+        run: exit 1
+
+  drift-prod:
+    name: Drift Check — prod
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.environment == 'all' ||
+      github.event.inputs.environment == 'prod'
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    env:
+      ENVIRONMENT: prod
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.PROD_DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+          role-session-name: github-actions-drift-prod
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
+      - name: Terraform Plan (drift check)
+        id: plan
+        run: |
+          set -o pipefail
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -detailed-exitcode \
+            -no-color \
+            2>&1 | tee plan_output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
+
+      - name: Upload drift report
+        if: steps.plan.outputs.exit_code == '2'
+        uses: actions/upload-artifact@v4
+        with:
+          name: drift-prod-${{ github.run_id }}
+          path: plan_output.txt
+          retention-days: 90
+
+      - name: Open issue on drift detected
+        if: steps.plan.outputs.exit_code == '2'
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('plan_output.txt', 'utf8');
+            const body = plan.length > 10000
+              ? plan.substring(0, 10000) + '\n\n...[truncated]'
+              : plan;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[Drift] Infrastructure drift detected in PRODUCTION (${new Date().toISOString().split('T')[0]})`,
+              labels: ['drift', 'infrastructure', 'production'],
+              body: `## Drift Detected in \`prod\`\n\n> **This is production.** Review carefully before taking any action.\n\n**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\n### Plan output\n\`\`\`\n${body}\n\`\`\``
+            });
+
+      - name: Fail on drift
+        if: steps.plan.outputs.exit_code == '2'
+        run: exit 1
+
+      - name: Fail on plan error
+        if: steps.plan.outputs.exit_code == '1'
+        run: exit 1

--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
-          role-to-assume: ${{ secrets.DEPLOY_ROLE }}
+          role-to-assume: ${{ secrets.DEV_DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
           role-session-name: github-actions-drift-dev
 

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -1,0 +1,182 @@
+name: Module Tests
+
+# Run Terraform native tests on every module that has changed.
+# Tests use mock providers — no AWS credentials or live resources required.
+# See tests/README.md for the testing strategy and how to add new tests.
+
+on:
+  pull_request:
+    paths:
+      - 'modules/**'
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths:
+      - 'modules/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  TF_VERSION: "1.7.5"
+
+jobs:
+  # Detect which modules have changed so we only test what's relevant.
+  # On workflow_dispatch (manual run) we test everything.
+  detect-changes:
+    name: Detect Changed Modules
+    runs-on: ubuntu-latest
+    outputs:
+      alb:        ${{ steps.changes.outputs.alb }}
+      compute:    ${{ steps.changes.outputs.compute }}
+      iam:        ${{ steps.changes.outputs.iam }}
+      kms:        ${{ steps.changes.outputs.kms }}
+      monitoring: ${{ steps.changes.outputs.monitoring }}
+      storage:    ${{ steps.changes.outputs.storage }}
+      vpc:        ${{ steps.changes.outputs.vpc }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Detect changed modules
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual run — test everything
+            echo "alb=true"        >> "$GITHUB_OUTPUT"
+            echo "compute=true"    >> "$GITHUB_OUTPUT"
+            echo "iam=true"        >> "$GITHUB_OUTPUT"
+            echo "kms=true"        >> "$GITHUB_OUTPUT"
+            echo "monitoring=true" >> "$GITHUB_OUTPUT"
+            echo "storage=true"    >> "$GITHUB_OUTPUT"
+            echo "vpc=true"        >> "$GITHUB_OUTPUT"
+          else
+            BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+            HEAD="${{ github.event.pull_request.head.sha || github.sha }}"
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+            echo "$CHANGED"
+
+            grep -q "^modules/alb/"                          <<< "$CHANGED" && echo "alb=true"        >> "$GITHUB_OUTPUT" || echo "alb=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/compute/"                      <<< "$CHANGED" && echo "compute=true"    >> "$GITHUB_OUTPUT" || echo "compute=false"    >> "$GITHUB_OUTPUT"
+            grep -q "^modules/iam/"                          <<< "$CHANGED" && echo "iam=true"        >> "$GITHUB_OUTPUT" || echo "iam=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/kms/"                          <<< "$CHANGED" && echo "kms=true"        >> "$GITHUB_OUTPUT" || echo "kms=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/monitoring/"                   <<< "$CHANGED" && echo "monitoring=true" >> "$GITHUB_OUTPUT" || echo "monitoring=false" >> "$GITHUB_OUTPUT"
+            grep -q "^modules/storage/"                      <<< "$CHANGED" && echo "storage=true"    >> "$GITHUB_OUTPUT" || echo "storage=false"    >> "$GITHUB_OUTPUT"
+            grep -q "^modules/networking/vpc-module/"        <<< "$CHANGED" && echo "vpc=true"        >> "$GITHUB_OUTPUT" || echo "vpc=false"        >> "$GITHUB_OUTPUT"
+          fi
+
+  test-kms:
+    name: Test — modules/kms
+    needs: detect-changes
+    if: needs.detect-changes.outputs.kms == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/kms init
+
+      - name: Run tests
+        run: terraform -chdir=modules/kms test -verbose
+
+  test-storage:
+    name: Test — modules/storage
+    needs: detect-changes
+    if: needs.detect-changes.outputs.storage == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/storage init
+
+      - name: Run tests
+        run: terraform -chdir=modules/storage test -verbose
+
+  test-alb:
+    name: Test — modules/alb
+    needs: detect-changes
+    if: needs.detect-changes.outputs.alb == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/alb init
+
+      - name: Run tests
+        run: terraform -chdir=modules/alb test -verbose
+
+  test-vpc:
+    name: Test — modules/networking/vpc-module
+    needs: detect-changes
+    if: needs.detect-changes.outputs.vpc == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/networking/vpc-module init
+
+      - name: Run tests
+        run: terraform -chdir=modules/networking/vpc-module test -verbose
+
+  # Summary job: required status check that passes when all relevant tests pass.
+  # Set this as a required PR check in branch protection rules.
+  # It passes even when no modules changed (all test jobs were skipped).
+  tests-passed:
+    name: Module Tests Passed
+    needs: [test-kms, test-storage, test-alb, test-vpc]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          results=(
+            "${{ needs.test-kms.result }}"
+            "${{ needs.test-storage.result }}"
+            "${{ needs.test-alb.result }}"
+            "${{ needs.test-vpc.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "One or more module tests failed: ${results[*]}"
+              exit 1
+            fi
+          done
+          echo "All module tests passed (or were skipped — no changes detected)."

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -24,6 +24,43 @@ env:
   TF_VERSION: "1.7.5"
 
 jobs:
+  # ── Static checks (always run) ──────────────────────────────────────────────
+  fmt-validate:
+    name: Format & Validate All Modules
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive modules/
+
+      - name: Validate each module
+        run: |
+          for module in \
+            modules/kms \
+            modules/storage \
+            modules/alb \
+            modules/compute \
+            modules/iam \
+            modules/monitoring \
+            modules/networking/vpc-module \
+            modules/networking/security-group-module \
+            modules/networking/vpc-endpoint-module; do
+            if [ -d "$module" ]; then
+              echo "==> Validating $module"
+              terraform -chdir="$module" init -backend=false -input=false > /dev/null
+              terraform -chdir="$module" validate
+            fi
+          done
+
   # Detect which modules have changed so we only test what's relevant.
   # On workflow_dispatch (manual run) we test everything.
   detect-changes:
@@ -158,12 +195,78 @@ jobs:
       - name: Run tests
         run: terraform -chdir=modules/networking/vpc-module test -verbose
 
+  test-compute:
+    name: Test — modules/compute
+    needs: detect-changes
+    if: needs.detect-changes.outputs.compute == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/compute init
+
+      - name: Run tests
+        run: terraform -chdir=modules/compute test -verbose
+
+  test-iam:
+    name: Test — modules/iam
+    needs: detect-changes
+    if: needs.detect-changes.outputs.iam == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/iam init
+
+      - name: Run tests
+        run: terraform -chdir=modules/iam test -verbose
+
+  test-monitoring:
+    name: Test — modules/monitoring
+    needs: detect-changes
+    if: needs.detect-changes.outputs.monitoring == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/monitoring init
+
+      - name: Run tests
+        run: terraform -chdir=modules/monitoring test -verbose
+
   # Summary job: required status check that passes when all relevant tests pass.
   # Set this as a required PR check in branch protection rules.
   # It passes even when no modules changed (all test jobs were skipped).
   tests-passed:
     name: Module Tests Passed
-    needs: [test-kms, test-storage, test-alb, test-vpc]
+    needs: [fmt-validate, test-kms, test-storage, test-alb, test-vpc, test-compute, test-iam, test-monitoring]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -174,6 +277,9 @@ jobs:
             "${{ needs.test-storage.result }}"
             "${{ needs.test-alb.result }}"
             "${{ needs.test-vpc.result }}"
+            "${{ needs.test-compute.result }}"
+            "${{ needs.test-iam.result }}"
+            "${{ needs.test-monitoring.result }}"
           )
           for result in "${results[@]}"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 env:
-  TF_VERSION: "1.7.5"
+  TF_VERSION: "1.10.5"
 
 jobs:
   # ── Static checks (always run) ──────────────────────────────────────────────
@@ -32,10 +32,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -67,16 +67,18 @@ jobs:
     name: Detect Changed Modules
     runs-on: ubuntu-latest
     outputs:
-      alb:        ${{ steps.changes.outputs.alb }}
-      compute:    ${{ steps.changes.outputs.compute }}
-      iam:        ${{ steps.changes.outputs.iam }}
-      kms:        ${{ steps.changes.outputs.kms }}
-      monitoring: ${{ steps.changes.outputs.monitoring }}
-      storage:    ${{ steps.changes.outputs.storage }}
-      vpc:        ${{ steps.changes.outputs.vpc }}
+      alb:          ${{ steps.changes.outputs.alb }}
+      compute:      ${{ steps.changes.outputs.compute }}
+      iam:          ${{ steps.changes.outputs.iam }}
+      kms:          ${{ steps.changes.outputs.kms }}
+      monitoring:   ${{ steps.changes.outputs.monitoring }}
+      storage:      ${{ steps.changes.outputs.storage }}
+      vpc:          ${{ steps.changes.outputs.vpc }}
+      sg:           ${{ steps.changes.outputs.sg }}
+      vpc-endpoint: ${{ steps.changes.outputs.vpc-endpoint }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -85,26 +87,30 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             # Manual run — test everything
-            echo "alb=true"        >> "$GITHUB_OUTPUT"
-            echo "compute=true"    >> "$GITHUB_OUTPUT"
-            echo "iam=true"        >> "$GITHUB_OUTPUT"
-            echo "kms=true"        >> "$GITHUB_OUTPUT"
-            echo "monitoring=true" >> "$GITHUB_OUTPUT"
-            echo "storage=true"    >> "$GITHUB_OUTPUT"
-            echo "vpc=true"        >> "$GITHUB_OUTPUT"
+            echo "alb=true"          >> "$GITHUB_OUTPUT"
+            echo "compute=true"      >> "$GITHUB_OUTPUT"
+            echo "iam=true"          >> "$GITHUB_OUTPUT"
+            echo "kms=true"          >> "$GITHUB_OUTPUT"
+            echo "monitoring=true"   >> "$GITHUB_OUTPUT"
+            echo "storage=true"      >> "$GITHUB_OUTPUT"
+            echo "vpc=true"          >> "$GITHUB_OUTPUT"
+            echo "sg=true"           >> "$GITHUB_OUTPUT"
+            echo "vpc-endpoint=true" >> "$GITHUB_OUTPUT"
           else
             BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
             HEAD="${{ github.event.pull_request.head.sha || github.sha }}"
             CHANGED=$(git diff --name-only "$BASE" "$HEAD")
             echo "$CHANGED"
 
-            grep -q "^modules/alb/"                   <<< "$CHANGED" && echo "alb=true"        >> "$GITHUB_OUTPUT" || echo "alb=false"        >> "$GITHUB_OUTPUT"
-            grep -q "^modules/compute/"               <<< "$CHANGED" && echo "compute=true"    >> "$GITHUB_OUTPUT" || echo "compute=false"    >> "$GITHUB_OUTPUT"
-            grep -q "^modules/iam/"                   <<< "$CHANGED" && echo "iam=true"        >> "$GITHUB_OUTPUT" || echo "iam=false"        >> "$GITHUB_OUTPUT"
-            grep -q "^modules/kms/"                   <<< "$CHANGED" && echo "kms=true"        >> "$GITHUB_OUTPUT" || echo "kms=false"        >> "$GITHUB_OUTPUT"
-            grep -q "^modules/monitoring/"            <<< "$CHANGED" && echo "monitoring=true" >> "$GITHUB_OUTPUT" || echo "monitoring=false" >> "$GITHUB_OUTPUT"
-            grep -q "^modules/storage/"               <<< "$CHANGED" && echo "storage=true"    >> "$GITHUB_OUTPUT" || echo "storage=false"    >> "$GITHUB_OUTPUT"
-            grep -q "^modules/networking/vpc-module/" <<< "$CHANGED" && echo "vpc=true"        >> "$GITHUB_OUTPUT" || echo "vpc=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/alb/"                                    <<< "$CHANGED" && echo "alb=true"          >> "$GITHUB_OUTPUT" || echo "alb=false"          >> "$GITHUB_OUTPUT"
+            grep -q "^modules/compute/"                                <<< "$CHANGED" && echo "compute=true"      >> "$GITHUB_OUTPUT" || echo "compute=false"      >> "$GITHUB_OUTPUT"
+            grep -q "^modules/iam/"                                    <<< "$CHANGED" && echo "iam=true"          >> "$GITHUB_OUTPUT" || echo "iam=false"          >> "$GITHUB_OUTPUT"
+            grep -q "^modules/kms/"                                    <<< "$CHANGED" && echo "kms=true"          >> "$GITHUB_OUTPUT" || echo "kms=false"          >> "$GITHUB_OUTPUT"
+            grep -q "^modules/monitoring/"                             <<< "$CHANGED" && echo "monitoring=true"   >> "$GITHUB_OUTPUT" || echo "monitoring=false"   >> "$GITHUB_OUTPUT"
+            grep -q "^modules/storage/"                                <<< "$CHANGED" && echo "storage=true"      >> "$GITHUB_OUTPUT" || echo "storage=false"      >> "$GITHUB_OUTPUT"
+            grep -q "^modules/networking/vpc-module/"                  <<< "$CHANGED" && echo "vpc=true"          >> "$GITHUB_OUTPUT" || echo "vpc=false"          >> "$GITHUB_OUTPUT"
+            grep -q "^modules/networking/security-group-module/"       <<< "$CHANGED" && echo "sg=true"           >> "$GITHUB_OUTPUT" || echo "sg=false"           >> "$GITHUB_OUTPUT"
+            grep -q "^modules/networking/vpc-endpoint-module/"         <<< "$CHANGED" && echo "vpc-endpoint=true" >> "$GITHUB_OUTPUT" || echo "vpc-endpoint=false" >> "$GITHUB_OUTPUT"
           fi
 
   test-kms:
@@ -116,10 +122,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -138,10 +144,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -160,10 +166,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -182,10 +188,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -204,10 +210,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -226,10 +232,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -248,10 +254,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
@@ -261,12 +267,56 @@ jobs:
       - name: Run tests
         run: terraform -chdir=modules/monitoring test -verbose
 
+  test-sg:
+    name: Test — modules/networking/security-group-module
+    needs: detect-changes
+    if: needs.detect-changes.outputs.sg == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/networking/security-group-module init
+
+      - name: Run tests
+        run: terraform -chdir=modules/networking/security-group-module test -verbose
+
+  test-vpc-endpoint:
+    name: Test — modules/networking/vpc-endpoint-module
+    needs: detect-changes
+    if: needs.detect-changes.outputs.vpc-endpoint == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform ${{ env.TF_VERSION }}
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Terraform Init
+        run: terraform -chdir=modules/networking/vpc-endpoint-module init
+
+      - name: Run tests
+        run: terraform -chdir=modules/networking/vpc-endpoint-module test -verbose
+
   # Summary job: required status check that passes when all relevant tests pass.
   # Set this as a required PR check in branch protection rules.
   # It passes even when no modules changed (all test jobs were skipped).
   tests-passed:
     name: Module Tests Passed
-    needs: [fmt-validate, test-kms, test-storage, test-alb, test-vpc, test-compute, test-iam, test-monitoring]
+    needs: [fmt-validate, test-kms, test-storage, test-alb, test-vpc, test-compute, test-iam, test-monitoring, test-sg, test-vpc-endpoint]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -280,6 +330,8 @@ jobs:
             "${{ needs.test-compute.result }}"
             "${{ needs.test-iam.result }}"
             "${{ needs.test-monitoring.result }}"
+            "${{ needs.test-sg.result }}"
+            "${{ needs.test-vpc-endpoint.result }}"
           )
           for result in "${results[@]}"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then

--- a/.github/workflows/module-tests.yml
+++ b/.github/workflows/module-tests.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 0
 
       - name: Detect changed modules
         id: changes
@@ -56,16 +58,16 @@ jobs:
           else
             BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
             HEAD="${{ github.event.pull_request.head.sha || github.sha }}"
-            CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+            CHANGED=$(git diff --name-only "$BASE" "$HEAD")
             echo "$CHANGED"
 
-            grep -q "^modules/alb/"                          <<< "$CHANGED" && echo "alb=true"        >> "$GITHUB_OUTPUT" || echo "alb=false"        >> "$GITHUB_OUTPUT"
-            grep -q "^modules/compute/"                      <<< "$CHANGED" && echo "compute=true"    >> "$GITHUB_OUTPUT" || echo "compute=false"    >> "$GITHUB_OUTPUT"
-            grep -q "^modules/iam/"                          <<< "$CHANGED" && echo "iam=true"        >> "$GITHUB_OUTPUT" || echo "iam=false"        >> "$GITHUB_OUTPUT"
-            grep -q "^modules/kms/"                          <<< "$CHANGED" && echo "kms=true"        >> "$GITHUB_OUTPUT" || echo "kms=false"        >> "$GITHUB_OUTPUT"
-            grep -q "^modules/monitoring/"                   <<< "$CHANGED" && echo "monitoring=true" >> "$GITHUB_OUTPUT" || echo "monitoring=false" >> "$GITHUB_OUTPUT"
-            grep -q "^modules/storage/"                      <<< "$CHANGED" && echo "storage=true"    >> "$GITHUB_OUTPUT" || echo "storage=false"    >> "$GITHUB_OUTPUT"
-            grep -q "^modules/networking/vpc-module/"        <<< "$CHANGED" && echo "vpc=true"        >> "$GITHUB_OUTPUT" || echo "vpc=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/alb/"                   <<< "$CHANGED" && echo "alb=true"        >> "$GITHUB_OUTPUT" || echo "alb=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/compute/"               <<< "$CHANGED" && echo "compute=true"    >> "$GITHUB_OUTPUT" || echo "compute=false"    >> "$GITHUB_OUTPUT"
+            grep -q "^modules/iam/"                   <<< "$CHANGED" && echo "iam=true"        >> "$GITHUB_OUTPUT" || echo "iam=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/kms/"                   <<< "$CHANGED" && echo "kms=true"        >> "$GITHUB_OUTPUT" || echo "kms=false"        >> "$GITHUB_OUTPUT"
+            grep -q "^modules/monitoring/"            <<< "$CHANGED" && echo "monitoring=true" >> "$GITHUB_OUTPUT" || echo "monitoring=false" >> "$GITHUB_OUTPUT"
+            grep -q "^modules/storage/"               <<< "$CHANGED" && echo "storage=true"    >> "$GITHUB_OUTPUT" || echo "storage=false"    >> "$GITHUB_OUTPUT"
+            grep -q "^modules/networking/vpc-module/" <<< "$CHANGED" && echo "vpc=true"        >> "$GITHUB_OUTPUT" || echo "vpc=false"        >> "$GITHUB_OUTPUT"
           fi
 
   test-kms:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -10,186 +10,230 @@ on:
   push:
     tags:
       - 'prod-*'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        default: 'plan'
+        type: choice
+        options:
+          - plan
+          - apply
 
+# Prevent concurrent deploys to the same environment.
+# For prod this is especially critical — never allow two applies to run
+# simultaneously, even if a reviewer approves a second run before the first finishes.
+concurrency:
+  group: terraform-prod
+  cancel-in-progress: false
+
+# Default to read-only. Individual jobs elevate only what they need.
 permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  actions: write
-  issues: write
+  contents: read
 
 env:
   AWS_ROLE_TO_ASSUME: ${{ secrets.PROD_DEPLOY_ROLE }}
   AWS_REGION: "us-west-2"
-  SECRET_KEY: ${{ secrets.GITHUB_TOKEN }}
   ENVIRONMENT: prod
+  TF_VERSION: "1.7.5"
+  CHECKOV_VERSION: "3.2.73"
 
 jobs:
   terraform:
     name: Terraform Validate & Plan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-prod-session
+          role-session-name: github-actions-prod-plan
 
-      - name: Setup Terraform
+      - name: Setup Terraform ${{ env.TF_VERSION }}
         uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
 
-      - name: Terraform Format
+      - name: Terraform Format Check
         run: terraform fmt -check -recursive
 
       - name: Terraform Init
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
 
       - name: Terraform Validate
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform validate
+        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} validate
 
       - name: Terraform Plan
-        id: terraform-plan
-        if: github.event_name == 'pull_request'
+        id: plan
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform plan -no-color 2>&1 | tee plan_output.txt
+          set -o pipefail
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -no-color \
+            -out=tfplan \
+            2>&1 | tee plan_output.txt
 
-      - name: Comment PR with Plan Result
+      - name: Upload plan artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-tfplan
+          path: environments/${{ env.ENVIRONMENT }}/tfplan
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Comment PR with plan output
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6.4.1
         with:
           script: |
             const fs = require('fs');
-            const outputFilePath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
-            const output = fs.readFileSync(outputFilePath, 'utf8');
-            const truncated = output.length > 65000
-              ? output.substring(0, 65000) + '\n\n... [truncated — see Actions logs for full output]'
-              : output;
+            const outputPath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
+            const raw = fs.readFileSync(outputPath, 'utf8');
+            const body = raw.length > 65000
+              ? raw.substring(0, 65000) + '\n\n...[truncated — see Actions logs for full output]'
+              : raw;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Prod Terraform Plan\n\`\`\`\n${truncated}\n\`\`\``
+              body: `## Prod — Terraform Plan\n\`\`\`\n${body}\n\`\`\``
             });
 
   checkov-scan:
     name: Checkov Security Scan
     needs: terraform
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v4.7.1
         with:
           python-version: '3.11'
 
-      - name: Install Checkov
-        run: pip install checkov
+      - name: Install Checkov (pinned)
+        run: pip install checkov==${{ env.CHECKOV_VERSION }}
 
       - name: Run Checkov
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          # CKV_TF_1: skipped — this repo uses local module paths (monorepo pattern).
-          # Local sources cannot be version-pinned; the git tag controls the version.
-          checkov -d . --download-external-modules true --skip-check CKV_TF_1
+          checkov \
+            --directory environments/${{ env.ENVIRONMENT }} \
+            --skip-check CKV_TF_1
 
   tflint-check:
     name: TFLint Check
     needs: terraform
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-prod-session
+          role-session-name: github-actions-prod-lint
 
       - name: Install TFLint
         run: |
-          wget https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip
-          unzip tflint_linux_amd64.zip
+          curl -sL \
+            https://github.com/terraform-linters/tflint/releases/download/v0.50.3/tflint_linux_amd64.zip \
+            -o tflint.zip
+          unzip tflint.zip
           sudo mv tflint /usr/local/bin/
 
-      - name: Install TFLint AWS Plugin
-        run: |
-          mkdir -p ~/.tflint.d/plugins
-          wget https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v0.27.0/tflint-ruleset-aws_linux_amd64.zip
-          unzip tflint-ruleset-aws_linux_amd64.zip -d ~/.tflint.d/plugins/
-
-      - name: Initialize TFLint
+      - name: TFLint Init
         run: tflint --init
 
       - name: Run TFLint
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          tflint
+        run: tflint --chdir=environments/${{ env.ENVIRONMENT }}
 
   # This job uses the GitHub Environment "prod-approval" which must be configured
-  # in Settings → Environments with required reviewers. The workflow will pause
-  # here until an authorised reviewer approves the deployment.
+  # in Settings → Environments with at least one required reviewer.
+  # The workflow pauses here until an authorised reviewer approves the deployment.
+  # Required status checks (terraform, checkov-scan, tflint-check) must pass first.
   approval-gate:
     name: Await Deployment Approval
     needs: [checkov-scan, tflint-check]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
     environment: prod-approval
+    permissions:
+      contents: read
     steps:
       - name: Deployment approved
-        run: echo "Deployment to production approved. Proceeding with apply."
+        run: echo "Deployment to production approved by ${{ github.actor }}. Proceeding."
 
   apply:
     name: Apply Terraform
     needs: [approval-gate]
     runs-on: ubuntu-latest
     environment: prod
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-prod-session
+          role-session-name: github-actions-prod-apply
 
-      - name: Setup Terraform
+      - name: Setup Terraform ${{ env.TF_VERSION }}
         uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
 
       - name: Terraform Init
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
+      # Generate a fresh plan immediately before apply.
+      # An approval can sit for hours before being actioned. A fresh plan ensures
+      # we apply exactly the current diff, not something computed before approval.
+      - name: Terraform Plan (pre-apply)
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -no-color \
+            -out=tfplan
 
       - name: Terraform Apply
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform apply -auto-approve 2>&1 | tee apply_output.txt
-          if grep -q "Error:" apply_output.txt; then
-            echo "Terraform apply failed. Check the logs for details."
-            exit 1
-          fi
+        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} apply tfplan
 
-      - name: Upload apply output
+      - name: Capture outputs
         if: always()
-        uses: actions/upload-artifact@v3
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} output -no-color \
+            > environments/${{ env.ENVIRONMENT }}/apply_output.txt 2>&1 || true
+
+      - name: Upload apply artefact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: prod-apply-output
-          path: environments/prod/apply_output.txt
+          path: environments/${{ env.ENVIRONMENT }}/apply_output.txt
+          retention-days: 90

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,4 +1,4 @@
-name: Prod Terraform CI
+name: Prod
 
 on:
   pull_request:
@@ -21,219 +21,23 @@ on:
           - plan
           - apply
 
-# Prevent concurrent deploys to the same environment.
-# For prod this is especially critical — never allow two applies to run
-# simultaneously, even if a reviewer approves a second run before the first finishes.
 concurrency:
   group: terraform-prod
   cancel-in-progress: false
 
-# Default to read-only. Individual jobs elevate only what they need.
 permissions:
   contents: read
 
-env:
-  AWS_ROLE_TO_ASSUME: ${{ secrets.PROD_DEPLOY_ROLE }}
-  AWS_REGION: "us-west-2"
-  ENVIRONMENT: prod
-  TF_VERSION: "1.7.5"
-  CHECKOV_VERSION: "3.2.73"
-
 jobs:
-  terraform:
-    name: Terraform Validate & Plan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-prod-plan
-
-      - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Terraform Format Check
-        run: terraform fmt -check -recursive
-
-      - name: Terraform Init
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
-            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
-
-      - name: Terraform Validate
-        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} validate
-
-      - name: Terraform Plan
-        id: plan
-        run: |
-          set -o pipefail
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
-            -no-color \
-            -out=tfplan \
-            2>&1 | tee plan_output.txt
-
-      - name: Upload plan artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: prod-tfplan
-          path: environments/${{ env.ENVIRONMENT }}/tfplan
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Comment PR with plan output
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const fs = require('fs');
-            const outputPath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
-            const raw = fs.readFileSync(outputPath, 'utf8');
-            const body = raw.length > 65000
-              ? raw.substring(0, 65000) + '\n\n...[truncated — see Actions logs for full output]'
-              : raw;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## Prod — Terraform Plan\n\`\`\`\n${body}\n\`\`\``
-            });
-
-  checkov-scan:
-    name: Checkov Security Scan
-    needs: terraform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Setup Python
-        uses: actions/setup-python@v4.7.1
-        with:
-          python-version: '3.11'
-
-      - name: Install Checkov (pinned)
-        run: pip install checkov==${{ env.CHECKOV_VERSION }}
-
-      - name: Run Checkov
-        run: |
-          checkov \
-            --directory environments/${{ env.ENVIRONMENT }} \
-            --skip-check CKV_TF_1
-
-  tflint-check:
-    name: TFLint Check
-    needs: terraform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-prod-lint
-
-      - name: Install TFLint
-        run: |
-          curl -sL \
-            https://github.com/terraform-linters/tflint/releases/download/v0.50.3/tflint_linux_amd64.zip \
-            -o tflint.zip
-          unzip tflint.zip
-          sudo mv tflint /usr/local/bin/
-
-      - name: TFLint Init
-        run: tflint --init
-
-      - name: Run TFLint
-        run: tflint --chdir=environments/${{ env.ENVIRONMENT }}
-
-  # This job uses the GitHub Environment "prod-approval" which must be configured
-  # in Settings → Environments with at least one required reviewer.
-  # The workflow pauses here until an authorised reviewer approves the deployment.
-  # Required status checks (terraform, checkov-scan, tflint-check) must pass first.
-  approval-gate:
-    name: Await Deployment Approval
-    needs: [checkov-scan, tflint-check]
-    runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
-    environment: prod-approval
-    permissions:
-      contents: read
-    steps:
-      - name: Deployment approved
-        run: echo "Deployment to production approved by ${{ github.actor }}. Proceeding."
-
-  apply:
-    name: Apply Terraform
-    needs: [approval-gate]
-    runs-on: ubuntu-latest
-    environment: prod
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-prod-apply
-
-      - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Terraform Init
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
-            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
-
-      # Generate a fresh plan immediately before apply.
-      # An approval can sit for hours before being actioned. A fresh plan ensures
-      # we apply exactly the current diff, not something computed before approval.
-      - name: Terraform Plan (pre-apply)
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
-            -no-color \
-            -out=tfplan
-
-      - name: Terraform Apply
-        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} apply tfplan
-
-      - name: Capture outputs
-        if: always()
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} output -no-color \
-            > environments/${{ env.ENVIRONMENT }}/apply_output.txt 2>&1 || true
-
-      - name: Upload apply artefact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: prod-apply-output
-          path: environments/${{ env.ENVIRONMENT }}/apply_output.txt
-          retention-days: 90
+  deploy:
+    uses: ./.github/workflows/terraform-deploy.yml
+    with:
+      environment: prod
+      run_apply: |
+        ${{
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')) ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+        }}
+      require_approval: true
+    secrets:
+      aws_role_arn: ${{ secrets.PROD_DEPLOY_ROLE }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,16 +1,15 @@
-name: Terraform CI
+name: Prod Terraform CI
 
 on:
   pull_request:
     paths:
       - 'environments/prod/**.tf'
+      - 'modules/**/*.tf'
     branches:
       - main
   push:
     tags:
       - 'prod-*'
-    paths:
-      - '**.tf'
 
 permissions:
   id-token: write
@@ -23,88 +22,63 @@ env:
   AWS_ROLE_TO_ASSUME: ${{ secrets.PROD_DEPLOY_ROLE }}
   AWS_REGION: "us-west-2"
   SECRET_KEY: ${{ secrets.GITHUB_TOKEN }}
+  ENVIRONMENT: prod
 
 jobs:
-
-  debug:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print event name and ref
-        run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Ref: ${{ github.ref }}"
-
   terraform:
-    name: Terraform
+    name: Terraform Validate & Plan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.0
         with:
           token: ${{ env.SECRET_KEY }}
 
-      - name: Determine Environment from Branch or Tag
-        run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "ENVIRONMENT=prod" >> $GITHUB_ENV # Default environment for pull requests
-          else
-            echo "ENVIRONMENT=$(echo ${{ github.ref }} | sed -e 's,refs/tags/,,g' | cut -d'-' -f1)" >> $GITHUB_ENV
-          fi
-
       - name: Configure AWS credentials from OIDC
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-session
+          role-session-name: github-actions-prod-session
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2.0.3
 
       - name: Terraform Format
-        run: terraform fmt -check
+        run: terraform fmt -check -recursive
 
       - name: Terraform Init
         run: |
           cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
           terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
       - name: Terraform Validate
         run: |
           cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
           terraform validate
-
-      - name: Print working directory
-        run: pwd
-
-      - name: List files in current directory
-        run: ls -al
-
-      - name: Print environment variables
-        run: printenv
 
       - name: Terraform Plan
         id: terraform-plan
         if: github.event_name == 'pull_request'
         run: |
           cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform plan -out=plan.tfplan -no-color > plan_output.txt
-
-      # Diagnostic step to list directory contents
-      - name: List directory contents
-        run: ls -al
+          terraform plan -no-color 2>&1 | tee plan_output.txt
 
       - name: Comment PR with Plan Result
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6.4.1
         with:
           script: |
-            var fs = require('fs');
-            var outputFilePath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
-            var output = fs.readFileSync(outputFilePath, 'utf8');
+            const fs = require('fs');
+            const outputFilePath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
+            const output = fs.readFileSync(outputFilePath, 'utf8');
+            const truncated = output.length > 65000
+              ? output.substring(0, 65000) + '\n\n... [truncated — see Actions logs for full output]'
+              : output;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: output
+              body: `## Prod Terraform Plan\n\`\`\`\n${truncated}\n\`\`\``
             });
 
   checkov-scan:
@@ -114,8 +88,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v4.7.1
@@ -127,6 +99,7 @@ jobs:
 
       - name: Run Checkov
         run: |
+          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
           checkov -d . --download-external-modules true --skip-check CKV_TF_1
 
   tflint-check:
@@ -136,64 +109,73 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
-    
+
       - name: Configure AWS credentials from OIDC
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-session
-    
+          role-session-name: github-actions-prod-session
+
       - name: Install TFLint
         run: |
-          wget https://github.com/terraform-linters/tflint/releases/download/v0.34.0/tflint_linux_amd64.zip
+          wget https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip
           unzip tflint_linux_amd64.zip
           sudo mv tflint /usr/local/bin/
-    
-      - name: Initialize TFLint AWS Plugin
+
+      - name: Install TFLint AWS Plugin
+        run: |
+          mkdir -p ~/.tflint.d/plugins
+          wget https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v0.27.0/tflint-ruleset-aws_linux_amd64.zip
+          unzip tflint-ruleset-aws_linux_amd64.zip -d ~/.tflint.d/plugins/
+
+      - name: Initialize TFLint
         run: tflint --init
-    
+
       - name: Run TFLint
-        run: tflint --loglevel debug
+        run: |
+          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
+          tflint
 
   apply:
     name: Apply Terraform
     needs: [checkov-scan, tflint-check]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && startsWith(github.ref, 'refs/tags/prod-') && contains(github.event.head_commit.modified, 'environments/prod/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')
+    environment: prod
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.0
         with:
           token: ${{ env.SECRET_KEY }}
 
-      - name: Determine Environment from Branch or Tag
-        run: |
-          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            echo "ENVIRONMENT=prod" >> $GITHUB_ENV
-          else
-            echo "ENVIRONMENT=$(echo ${{ github.ref }} | sed -e 's,refs/tags/,,g' | cut -d'-' -f1)" >> $GITHUB_ENV
-          fi
-
       - name: Configure AWS credentials from OIDC
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-session
+          role-session-name: github-actions-prod-session
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2.0.3
 
+      - name: Terraform Init
+        run: |
+          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
+          terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
       - name: Terraform Apply
         run: |
-          set +e
-          ENVIRONMENT=$(echo ${{ github.ref }} | sed -e 's,refs/tags/,,g' | cut -d'-' -f1)
-          cd environments/$ENVIRONMENT
-          terraform apply -auto-approve > apply_output.txt
+          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
+          terraform apply -auto-approve 2>&1 | tee apply_output.txt
           if grep -q "Error:" apply_output.txt; then
             echo "Terraform apply failed. Check the logs for details."
             exit 1
           fi
+
+      - name: Upload apply output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: prod-apply-output
+          path: environments/prod/apply_output.txt

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -137,11 +137,23 @@ jobs:
           cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
           tflint
 
-  apply:
-    name: Apply Terraform
+  # This job uses the GitHub Environment "prod-approval" which must be configured
+  # in Settings → Environments with required reviewers. The workflow will pause
+  # here until an authorised reviewer approves the deployment.
+  approval-gate:
+    name: Await Deployment Approval
     needs: [checkov-scan, tflint-check]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')
+    environment: prod-approval
+    steps:
+      - name: Deployment approved
+        run: echo "Deployment to production approved. Proceeding with apply."
+
+  apply:
+    name: Apply Terraform
+    needs: [approval-gate]
+    runs-on: ubuntu-latest
     environment: prod
     steps:
       - name: Checkout code

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -38,3 +38,4 @@ jobs:
     secrets:
       aws_role_arn: ${{ secrets.PROD_DEPLOY_ROLE }}
       infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}
+      aws_account_id: ${{ secrets.PROD_AWS_ACCOUNT_ID }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -100,6 +100,8 @@ jobs:
       - name: Run Checkov
         run: |
           cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
+          # CKV_TF_1: skipped — this repo uses local module paths (monorepo pattern).
+          # Local sources cannot be version-pinned; the git tag controls the version.
           checkov -d . --download-external-modules true --skip-check CKV_TF_1
 
   tflint-check:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -41,3 +41,4 @@ jobs:
       require_approval: true
     secrets:
       aws_role_arn: ${{ secrets.PROD_DEPLOY_ROLE }}
+      infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -33,11 +33,7 @@ jobs:
     uses: ./.github/workflows/terraform-deploy.yml
     with:
       environment: prod
-      run_apply: |
-        ${{
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')) ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
-        }}
+      run_apply: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod-')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply') }}
       require_approval: true
     secrets:
       aws_role_arn: ${{ secrets.PROD_DEPLOY_ROLE }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,61 @@
+name: Secret Scan
+
+# Detect secrets, credentials, and API keys accidentally committed to the repo.
+# Uses Gitleaks — an open-source SAST tool for detecting hardcoded secrets.
+# https://github.com/gitleaks/gitleaks
+#
+# On PRs: scans only the commits in the PR (fast, targeted).
+# On push to main: scans the full repository history (catches anything merged).
+# On schedule: weekly full-history scan as a safety net.
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * 1'  # Weekly on Monday at 05:00 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks Secret Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+        with:
+          fetch-depth: 0  # Full history required for complete scan
+
+      - name: Run Gitleaks (PR — scan changed commits only)
+        if: github.event_name == 'pull_request'
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}  # Only required for org-level repos
+        with:
+          args: detect
+            --source .
+            --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+            --redact
+            --no-git
+
+      - name: Run Gitleaks (full history scan)
+        if: github.event_name != 'pull_request'
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        with:
+          args: detect --source . --redact

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -33,11 +33,7 @@ jobs:
     uses: ./.github/workflows/terraform-deploy.yml
     with:
       environment: staging
-      run_apply: |
-        ${{
-          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/staging-')) ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
-        }}
+      run_apply: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/staging-')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply') }}
       require_approval: false
     secrets:
       aws_role_arn: ${{ secrets.STAGING_DEPLOY_ROLE }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -38,3 +38,4 @@ jobs:
     secrets:
       aws_role_arn: ${{ secrets.STAGING_DEPLOY_ROLE }}
       infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}
+      aws_account_id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -41,3 +41,4 @@ jobs:
       require_approval: false
     secrets:
       aws_role_arn: ${{ secrets.STAGING_DEPLOY_ROLE }}
+      infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,4 +1,4 @@
-name: Staging Terraform CI
+name: Staging
 
 on:
   pull_request:
@@ -21,200 +21,23 @@ on:
           - plan
           - apply
 
-# Prevent concurrent deploys to the same environment.
 concurrency:
   group: terraform-staging
   cancel-in-progress: false
 
-# Default to read-only. Individual jobs elevate only what they need.
 permissions:
   contents: read
 
-env:
-  AWS_ROLE_TO_ASSUME: ${{ secrets.STAGING_DEPLOY_ROLE }}
-  AWS_REGION: "us-west-2"
-  ENVIRONMENT: staging
-  TF_VERSION: "1.7.5"
-  CHECKOV_VERSION: "3.2.73"
-
 jobs:
-  terraform:
-    name: Terraform Validate & Plan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-staging-plan
-
-      - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Terraform Format Check
-        run: terraform fmt -check -recursive
-
-      - name: Terraform Init
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
-            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
-
-      - name: Terraform Validate
-        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} validate
-
-      - name: Terraform Plan
-        id: plan
-        run: |
-          set -o pipefail
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
-            -no-color \
-            -out=tfplan \
-            2>&1 | tee plan_output.txt
-
-      - name: Upload plan artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: staging-tfplan
-          path: environments/${{ env.ENVIRONMENT }}/tfplan
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Comment PR with plan output
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6.4.1
-        with:
-          script: |
-            const fs = require('fs');
-            const outputPath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
-            const raw = fs.readFileSync(outputPath, 'utf8');
-            const body = raw.length > 65000
-              ? raw.substring(0, 65000) + '\n\n...[truncated — see Actions logs for full output]'
-              : raw;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## Staging — Terraform Plan\n\`\`\`\n${body}\n\`\`\``
-            });
-
-  checkov-scan:
-    name: Checkov Security Scan
-    needs: terraform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Setup Python
-        uses: actions/setup-python@v4.7.1
-        with:
-          python-version: '3.11'
-
-      - name: Install Checkov (pinned)
-        run: pip install checkov==${{ env.CHECKOV_VERSION }}
-
-      - name: Run Checkov
-        run: |
-          checkov \
-            --directory environments/${{ env.ENVIRONMENT }} \
-            --skip-check CKV_TF_1
-
-  tflint-check:
-    name: TFLint Check
-    needs: terraform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-staging-lint
-
-      - name: Install TFLint
-        run: |
-          curl -sL \
-            https://github.com/terraform-linters/tflint/releases/download/v0.50.3/tflint_linux_amd64.zip \
-            -o tflint.zip
-          unzip tflint.zip
-          sudo mv tflint /usr/local/bin/
-
-      - name: TFLint Init
-        run: tflint --init
-
-      - name: Run TFLint
-        run: tflint --chdir=environments/${{ env.ENVIRONMENT }}
-
-  apply:
-    name: Apply Terraform
-    needs: [checkov-scan, tflint-check]
-    runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/staging-')) ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
-    environment: staging
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.0
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4.0.1
-        with:
-          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
-          aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-staging-apply
-
-      - name: Setup Terraform ${{ env.TF_VERSION }}
-        uses: hashicorp/setup-terraform@v2.0.3
-        with:
-          terraform_version: ${{ env.TF_VERSION }}
-
-      - name: Terraform Init
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
-            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
-
-      # Generate a fresh plan immediately before apply.
-      - name: Terraform Plan (pre-apply)
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
-            -no-color \
-            -out=tfplan
-
-      - name: Terraform Apply
-        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} apply tfplan
-
-      - name: Capture outputs
-        if: always()
-        run: |
-          terraform -chdir=environments/${{ env.ENVIRONMENT }} output -no-color \
-            > environments/${{ env.ENVIRONMENT }}/apply_output.txt 2>&1 || true
-
-      - name: Upload apply artefact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: staging-apply-output
-          path: environments/${{ env.ENVIRONMENT }}/apply_output.txt
-          retention-days: 30
+  deploy:
+    uses: ./.github/workflows/terraform-deploy.yml
+    with:
+      environment: staging
+      run_apply: |
+        ${{
+          (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/staging-')) ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
+        }}
+      require_approval: false
+    secrets:
+      aws_role_arn: ${{ secrets.STAGING_DEPLOY_ROLE }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,15 +1,15 @@
-name: Dev Terraform CI
+name: Staging Terraform CI
 
 on:
   pull_request:
     paths:
-      - 'environments/dev/**.tf'
+      - 'environments/staging/**.tf'
       - 'modules/**/*.tf'
     branches:
       - main
   push:
     tags:
-      - 'dev-*'
+      - 'staging-*'
 
 permissions:
   id-token: write
@@ -19,10 +19,10 @@ permissions:
   issues: write
 
 env:
-  AWS_ROLE_TO_ASSUME: ${{ secrets.DEPLOY_ROLE }}
+  AWS_ROLE_TO_ASSUME: ${{ secrets.STAGING_DEPLOY_ROLE }}
   AWS_REGION: "us-west-2"
   SECRET_KEY: ${{ secrets.GITHUB_TOKEN }}
-  ENVIRONMENT: dev
+  ENVIRONMENT: staging
 
 jobs:
   terraform:
@@ -38,7 +38,7 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-session
+          role-session-name: github-actions-staging-session
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2.0.3
@@ -78,7 +78,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Dev Terraform Plan\n\`\`\`\n${truncated}\n\`\`\``
+              body: `## Staging Terraform Plan\n\`\`\`\n${truncated}\n\`\`\``
             });
 
   checkov-scan:
@@ -115,7 +115,7 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-session
+          role-session-name: github-actions-staging-session
 
       - name: Install TFLint
         run: |
@@ -141,8 +141,8 @@ jobs:
     name: Apply Terraform
     needs: [checkov-scan, tflint-check]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dev-')
-    environment: dev
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/staging-')
+    environment: staging
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.0
@@ -154,7 +154,7 @@ jobs:
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-dev-session
+          role-session-name: github-actions-staging-session
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2.0.3
@@ -177,5 +177,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: dev-apply-output
-          path: environments/dev/apply_output.txt
+          name: staging-apply-output
+          path: environments/staging/apply_output.txt

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -10,174 +10,211 @@ on:
   push:
     tags:
       - 'staging-*'
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        default: 'plan'
+        type: choice
+        options:
+          - plan
+          - apply
 
+# Prevent concurrent deploys to the same environment.
+concurrency:
+  group: terraform-staging
+  cancel-in-progress: false
+
+# Default to read-only. Individual jobs elevate only what they need.
 permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
-  actions: write
-  issues: write
+  contents: read
 
 env:
   AWS_ROLE_TO_ASSUME: ${{ secrets.STAGING_DEPLOY_ROLE }}
   AWS_REGION: "us-west-2"
-  SECRET_KEY: ${{ secrets.GITHUB_TOKEN }}
   ENVIRONMENT: staging
+  TF_VERSION: "1.7.5"
+  CHECKOV_VERSION: "3.2.73"
 
 jobs:
   terraform:
     name: Terraform Validate & Plan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-staging-session
+          role-session-name: github-actions-staging-plan
 
-      - name: Setup Terraform
+      - name: Setup Terraform ${{ env.TF_VERSION }}
         uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
 
-      - name: Terraform Format
+      - name: Terraform Format Check
         run: terraform fmt -check -recursive
 
       - name: Terraform Init
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
 
       - name: Terraform Validate
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform validate
+        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} validate
 
       - name: Terraform Plan
-        id: terraform-plan
-        if: github.event_name == 'pull_request'
+        id: plan
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform plan -no-color 2>&1 | tee plan_output.txt
+          set -o pipefail
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -no-color \
+            -out=tfplan \
+            2>&1 | tee plan_output.txt
 
-      - name: Comment PR with Plan Result
+      - name: Upload plan artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-tfplan
+          path: environments/${{ env.ENVIRONMENT }}/tfplan
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Comment PR with plan output
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v6.4.1
         with:
           script: |
             const fs = require('fs');
-            const outputFilePath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
-            const output = fs.readFileSync(outputFilePath, 'utf8');
-            const truncated = output.length > 65000
-              ? output.substring(0, 65000) + '\n\n... [truncated — see Actions logs for full output]'
-              : output;
+            const outputPath = `${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}/plan_output.txt`;
+            const raw = fs.readFileSync(outputPath, 'utf8');
+            const body = raw.length > 65000
+              ? raw.substring(0, 65000) + '\n\n...[truncated — see Actions logs for full output]'
+              : raw;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Staging Terraform Plan\n\`\`\`\n${truncated}\n\`\`\``
+              body: `## Staging — Terraform Plan\n\`\`\`\n${body}\n\`\`\``
             });
 
   checkov-scan:
     name: Checkov Security Scan
     needs: terraform
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v4.7.1
         with:
           python-version: '3.11'
 
-      - name: Install Checkov
-        run: pip install checkov
+      - name: Install Checkov (pinned)
+        run: pip install checkov==${{ env.CHECKOV_VERSION }}
 
       - name: Run Checkov
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          # CKV_TF_1: skipped — this repo uses local module paths (monorepo pattern).
-          # Local sources cannot be version-pinned; the git tag controls the version.
-          checkov -d . --download-external-modules true --skip-check CKV_TF_1
+          checkov \
+            --directory environments/${{ env.ENVIRONMENT }} \
+            --skip-check CKV_TF_1
 
   tflint-check:
     name: TFLint Check
     needs: terraform
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-staging-session
+          role-session-name: github-actions-staging-lint
 
       - name: Install TFLint
         run: |
-          wget https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip
-          unzip tflint_linux_amd64.zip
+          curl -sL \
+            https://github.com/terraform-linters/tflint/releases/download/v0.50.3/tflint_linux_amd64.zip \
+            -o tflint.zip
+          unzip tflint.zip
           sudo mv tflint /usr/local/bin/
 
-      - name: Install TFLint AWS Plugin
-        run: |
-          mkdir -p ~/.tflint.d/plugins
-          wget https://github.com/terraform-linters/tflint-ruleset-aws/releases/download/v0.27.0/tflint-ruleset-aws_linux_amd64.zip
-          unzip tflint-ruleset-aws_linux_amd64.zip -d ~/.tflint.d/plugins/
-
-      - name: Initialize TFLint
+      - name: TFLint Init
         run: tflint --init
 
       - name: Run TFLint
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          tflint
+        run: tflint --chdir=environments/${{ env.ENVIRONMENT }}
 
   apply:
     name: Apply Terraform
     needs: [checkov-scan, tflint-check]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/staging-')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/staging-')) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
     environment: staging
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4.1.0
-        with:
-          token: ${{ env.SECRET_KEY }}
 
-      - name: Configure AWS credentials from OIDC
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
-          role-session-name: github-actions-staging-session
+          role-session-name: github-actions-staging-apply
 
-      - name: Setup Terraform
+      - name: Setup Terraform ${{ env.TF_VERSION }}
         uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
 
       - name: Terraform Init
         run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform init -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} init \
+            -backend-config="key=${ENVIRONMENT}/terraform.tfstate"
+
+      # Generate a fresh plan immediately before apply.
+      - name: Terraform Plan (pre-apply)
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} plan \
+            -no-color \
+            -out=tfplan
 
       - name: Terraform Apply
-        run: |
-          cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
-          terraform apply -auto-approve 2>&1 | tee apply_output.txt
-          if grep -q "Error:" apply_output.txt; then
-            echo "Terraform apply failed. Check the logs for details."
-            exit 1
-          fi
+        run: terraform -chdir=environments/${{ env.ENVIRONMENT }} apply tfplan
 
-      - name: Upload apply output
+      - name: Capture outputs
         if: always()
-        uses: actions/upload-artifact@v3
+        run: |
+          terraform -chdir=environments/${{ env.ENVIRONMENT }} output -no-color \
+            > environments/${{ env.ENVIRONMENT }}/apply_output.txt 2>&1 || true
+
+      - name: Upload apply artefact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: staging-apply-output
-          path: environments/staging/apply_output.txt
+          path: environments/${{ env.ENVIRONMENT }}/apply_output.txt
+          retention-days: 30

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -100,6 +100,8 @@ jobs:
       - name: Run Checkov
         run: |
           cd ${{ github.workspace }}/environments/${{ env.ENVIRONMENT }}
+          # CKV_TF_1: skipped — this repo uses local module paths (monorepo pattern).
+          # Local sources cannot be version-pinned; the git tag controls the version.
           checkov -d . --download-external-modules true --skip-check CKV_TF_1
 
   tflint-check:

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -1,0 +1,269 @@
+# Reusable Terraform deployment workflow.
+# Called by dev.yml, staging.yml, and prod.yml — not triggered directly.
+#
+# Usage:
+#   jobs:
+#     deploy:
+#       uses: ./.github/workflows/terraform-deploy.yml
+#       with:
+#         environment: dev
+#         aws_region: us-west-2
+#         tf_version: "1.7.5"
+#         checkov_version: "3.2.73"
+#         require_approval: false
+#       secrets:
+#         aws_role_arn: ${{ secrets.DEV_DEPLOY_ROLE }}
+
+name: Terraform Deploy (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Target environment (dev, staging, prod)'
+        required: true
+        type: string
+      aws_region:
+        description: 'AWS region'
+        required: false
+        type: string
+        default: 'us-west-2'
+      tf_version:
+        description: 'Terraform version to use'
+        required: false
+        type: string
+        default: '1.7.5'
+      checkov_version:
+        description: 'Checkov version to use'
+        required: false
+        type: string
+        default: '3.2.73'
+      run_apply:
+        description: 'Whether to run terraform apply after validation'
+        required: false
+        type: boolean
+        default: false
+      require_approval:
+        description: 'Whether to require manual approval before apply (prod)'
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      aws_role_arn:
+        description: 'IAM role ARN to assume via OIDC'
+        required: true
+
+jobs:
+  # ── Validate & Plan ──────────────────────────────────────────────────────────
+  plan:
+    name: Plan (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    outputs:
+      plan_exit_code: ${{ steps.plan.outputs.exit_code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+          role-session-name: github-actions-${{ inputs.environment }}-plan
+
+      - name: Setup Terraform ${{ inputs.tf_version }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ inputs.tf_version }}
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=environments/${{ inputs.environment }} init \
+            -backend-config="key=${{ inputs.environment }}/terraform.tfstate"
+
+      - name: Terraform Validate
+        run: terraform -chdir=environments/${{ inputs.environment }} validate
+
+      - name: Terraform Plan
+        id: plan
+        run: |
+          set -o pipefail
+          terraform -chdir=environments/${{ inputs.environment }} plan \
+            -no-color \
+            -out=tfplan \
+            2>&1 | tee plan_output.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload plan artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.environment }}-tfplan-${{ github.run_id }}
+          path: environments/${{ inputs.environment }}/tfplan
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Comment PR with plan output
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6.4.1
+        with:
+          script: |
+            const fs = require('fs');
+            const env = '${{ inputs.environment }}';
+            const outputPath = `${{ github.workspace }}/environments/${env}/plan_output.txt`;
+            const raw = fs.readFileSync(outputPath, 'utf8');
+            const body = raw.length > 65000
+              ? raw.substring(0, 65000) + '\n\n...[truncated — see Actions logs for full output]'
+              : raw;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## ${env.charAt(0).toUpperCase() + env.slice(1)} — Terraform Plan\n\`\`\`\n${body}\n\`\`\``
+            });
+
+  # ── Security Scan ────────────────────────────────────────────────────────────
+  checkov:
+    name: Checkov (${{ inputs.environment }})
+    needs: plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4.7.1
+        with:
+          python-version: '3.11'
+
+      - name: Install Checkov (pinned)
+        run: pip install checkov==${{ inputs.checkov_version }}
+
+      - name: Run Checkov
+        run: |
+          checkov \
+            --directory environments/${{ inputs.environment }} \
+            --skip-check CKV_TF_1
+          # CKV_TF_1: local monorepo modules are version-controlled via git tags.
+
+  # ── Static Analysis ──────────────────────────────────────────────────────────
+  tflint:
+    name: TFLint (${{ inputs.environment }})
+    needs: plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+          role-session-name: github-actions-${{ inputs.environment }}-lint
+
+      - name: Install TFLint
+        run: |
+          curl -sL \
+            https://github.com/terraform-linters/tflint/releases/download/v0.50.3/tflint_linux_amd64.zip \
+            -o tflint.zip
+          unzip tflint.zip
+          sudo mv tflint /usr/local/bin/
+
+      - name: TFLint Init
+        run: tflint --init
+
+      - name: Run TFLint
+        run: tflint --chdir=environments/${{ inputs.environment }}
+
+  # ── Approval Gate (prod only) ────────────────────────────────────────────────
+  # The GitHub Environment "prod-approval" must be configured in
+  # Settings → Environments with at least one required reviewer.
+  approval:
+    name: Await Approval (${{ inputs.environment }})
+    needs: [checkov, tflint]
+    runs-on: ubuntu-latest
+    if: inputs.run_apply && inputs.require_approval
+    environment: prod-approval
+    permissions:
+      contents: read
+    steps:
+      - name: Approved
+        run: echo "Deployment to ${{ inputs.environment }} approved by ${{ github.actor }}."
+
+  # ── Apply ────────────────────────────────────────────────────────────────────
+  apply:
+    name: Apply (${{ inputs.environment }})
+    # For prod: wait for manual approval. For dev/staging: wait for checks only.
+    needs:
+      - checkov
+      - tflint
+      - approval
+    # approval job is skipped for dev/staging (needs skipped = needs passed for this purpose)
+    if: |
+      always() &&
+      inputs.run_apply &&
+      needs.checkov.result == 'success' &&
+      needs.tflint.result == 'success' &&
+      (needs.approval.result == 'success' || needs.approval.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+          role-session-name: github-actions-${{ inputs.environment }}-apply
+
+      - name: Setup Terraform ${{ inputs.tf_version }}
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ inputs.tf_version }}
+
+      - name: Terraform Init
+        run: |
+          terraform -chdir=environments/${{ inputs.environment }} init \
+            -backend-config="key=${{ inputs.environment }}/terraform.tfstate"
+
+      # Generate a fresh plan immediately before apply.
+      # The plan from the check stage may be stale if approval took time.
+      - name: Terraform Plan (pre-apply)
+        run: |
+          terraform -chdir=environments/${{ inputs.environment }} plan \
+            -no-color \
+            -out=tfplan
+
+      - name: Terraform Apply
+        run: terraform -chdir=environments/${{ inputs.environment }} apply tfplan
+
+      - name: Capture outputs
+        if: always()
+        run: |
+          terraform -chdir=environments/${{ inputs.environment }} output -no-color \
+            > environments/${{ inputs.environment }}/apply_output.txt 2>&1 || true
+
+      - name: Upload apply artefact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.environment }}-apply-${{ github.run_id }}
+          path: environments/${{ inputs.environment }}/apply_output.txt
+          retention-days: ${{ inputs.environment == 'prod' && 90 || 30 }}

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -54,6 +54,9 @@ on:
       infracost_api_key:
         description: 'Infracost API key for cost estimation (optional — job is skipped when absent)'
         required: false
+      aws_account_id:
+        description: 'AWS account ID for the target environment — sets TF_VAR_account_id'
+        required: true
 
 jobs:
   # ── Validate & Plan ──────────────────────────────────────────────────────────
@@ -64,6 +67,8 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
+    env:
+      TF_VAR_account_id: ${{ secrets.aws_account_id }}
     outputs:
       plan_exit_code: ${{ steps.plan.outputs.exit_code }}
     steps:
@@ -321,6 +326,8 @@ jobs:
       (needs.approval.result == 'success' || needs.approval.result == 'skipped')
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    env:
+      TF_VAR_account_id: ${{ secrets.aws_account_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -7,12 +7,11 @@
 #       uses: ./.github/workflows/terraform-deploy.yml
 #       with:
 #         environment: dev
-#         aws_region: us-west-2
-#         tf_version: "1.7.5"
-#         checkov_version: "3.2.73"
+#         run_apply: false
 #         require_approval: false
 #       secrets:
 #         aws_role_arn: ${{ secrets.DEV_DEPLOY_ROLE }}
+#         infracost_api_key: ${{ secrets.INFRACOST_API_KEY }}   # optional
 
 name: Terraform Deploy (Reusable)
 
@@ -52,6 +51,9 @@ on:
       aws_role_arn:
         description: 'IAM role ARN to assume via OIDC'
         required: true
+      infracost_api_key:
+        description: 'Infracost API key for cost estimation (optional — job is skipped when absent)'
+        required: false
 
 jobs:
   # ── Validate & Plan ──────────────────────────────────────────────────────────
@@ -79,6 +81,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: ${{ inputs.tf_version }}
+          terraform_wrapper: false   # Must be false for Infracost JSON parsing
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
@@ -101,11 +104,18 @@ jobs:
             2>&1 | tee plan_output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
+      - name: Convert plan to JSON (for Infracost)
+        run: |
+          terraform -chdir=environments/${{ inputs.environment }} \
+            show -json tfplan > /tmp/plan.json
+
       - name: Upload plan artefact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.environment }}-tfplan-${{ github.run_id }}
-          path: environments/${{ inputs.environment }}/tfplan
+          path: |
+            environments/${{ inputs.environment }}/tfplan
+            /tmp/plan.json
           retention-days: 1
           if-no-files-found: error
 
@@ -129,8 +139,13 @@ jobs:
             });
 
   # ── Security Scan ────────────────────────────────────────────────────────────
+  # Checkov performs static analysis against ~1,000 AWS security policies.
+  # It checks the Terraform source files (not the plan) for misconfigurations
+  # including: missing encryption, public S3 access, open security groups,
+  # missing logging, weak IAM policies, disabled MFA, and more.
+  # https://www.checkov.io/5.Policy%20Index/terraform.html
   checkov:
-    name: Checkov (${{ inputs.environment }})
+    name: Checkov Security Scan (${{ inputs.environment }})
     needs: plan
     runs-on: ubuntu-latest
     permissions:
@@ -151,8 +166,12 @@ jobs:
         run: |
           checkov \
             --directory environments/${{ inputs.environment }} \
-            --skip-check CKV_TF_1
+            --skip-check CKV_TF_1 \
+            --compact \
+            --quiet
           # CKV_TF_1: local monorepo modules are version-controlled via git tags.
+          # --compact: show only failed checks (reduces noise in CI output)
+          # --quiet:   suppress the progress bar
 
   # ── Static Analysis ──────────────────────────────────────────────────────────
   tflint:
@@ -187,6 +206,90 @@ jobs:
       - name: Run TFLint
         run: tflint --chdir=environments/${{ inputs.environment }}
 
+  # ── Cost Estimation ───────────────────────────────────────────────────────────
+  # Infracost analyses the Terraform plan and posts a cost breakdown as a PR
+  # comment. It shows the monthly cost of every resource being added, changed,
+  # or removed — including the total diff.
+  #
+  # Setup:
+  #   1. Sign up for a free API key at https://www.infracost.io/docs/
+  #   2. Add INFRACOST_API_KEY as a GitHub repository secret
+  #   3. Pass it to this workflow as secrets.infracost_api_key
+  #
+  # If the secret is absent this job is silently skipped — it never blocks apply.
+  infracost:
+    name: Cost Estimate (${{ inputs.environment }})
+    needs: plan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+
+      - name: Check for Infracost API key
+        id: check-key
+        run: |
+          if [ -z "$INFRACOST_API_KEY" ]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "Infracost API key not configured — skipping cost estimate."
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          INFRACOST_API_KEY: ${{ secrets.infracost_api_key }}
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.check-key.outputs.present == 'true'
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.aws_role_arn }}
+          aws-region: ${{ inputs.aws_region }}
+          role-session-name: github-actions-${{ inputs.environment }}-cost
+
+      - name: Setup Terraform ${{ inputs.tf_version }}
+        if: steps.check-key.outputs.present == 'true'
+        uses: hashicorp/setup-terraform@v2.0.3
+        with:
+          terraform_version: ${{ inputs.tf_version }}
+          terraform_wrapper: false   # Required — Infracost needs raw terraform output
+
+      - name: Terraform Init
+        if: steps.check-key.outputs.present == 'true'
+        run: |
+          terraform -chdir=environments/${{ inputs.environment }} init \
+            -backend-config="key=${{ inputs.environment }}/terraform.tfstate"
+
+      - name: Setup Infracost
+        if: steps.check-key.outputs.present == 'true'
+        uses: infracost/actions/setup@v3
+        with:
+          api-key: ${{ secrets.infracost_api_key }}
+
+      - name: Generate cost breakdown from Terraform plan
+        if: steps.check-key.outputs.present == 'true'
+        run: |
+          infracost breakdown \
+            --path=environments/${{ inputs.environment }} \
+            --terraform-init-flags="-backend-config=key=${{ inputs.environment }}/terraform.tfstate" \
+            --format=json \
+            --out-file=/tmp/infracost.json
+
+      - name: Post cost estimate as PR comment
+        if: steps.check-key.outputs.present == 'true'
+        run: |
+          infracost comment github \
+            --path=/tmp/infracost.json \
+            --repo=${{ github.repository }} \
+            --github-token=${{ github.token }} \
+            --pull-request=${{ github.event.pull_request.number }} \
+            --behavior=update
+        # --behavior=update: replaces the previous Infracost comment instead of
+        # adding a new one on every push — keeps the PR timeline clean
+
   # ── Approval Gate (prod only) ────────────────────────────────────────────────
   # The GitHub Environment "prod-approval" must be configured in
   # Settings → Environments with at least one required reviewer.
@@ -205,12 +308,11 @@ jobs:
   # ── Apply ────────────────────────────────────────────────────────────────────
   apply:
     name: Apply (${{ inputs.environment }})
-    # For prod: wait for manual approval. For dev/staging: wait for checks only.
     needs:
       - checkov
       - tflint
       - approval
-    # approval job is skipped for dev/staging (needs skipped = needs passed for this purpose)
+    # approval is skipped for dev/staging — skipped counts as passed here
     if: |
       always() &&
       inputs.run_apply &&
@@ -237,6 +339,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: ${{ inputs.tf_version }}
+          terraform_wrapper: false
 
       - name: Terraform Init
         run: |

--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -31,7 +31,7 @@ on:
         description: 'Terraform version to use'
         required: false
         type: string
-        default: '1.7.5'
+        default: '1.10.5'
       checkov_version:
         description: 'Checkov version to use'
         required: false
@@ -73,7 +73,7 @@ jobs:
       plan_exit_code: ${{ steps.plan.outputs.exit_code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
@@ -83,7 +83,7 @@ jobs:
           role-session-name: github-actions-${{ inputs.environment }}-plan
 
       - name: Setup Terraform ${{ inputs.tf_version }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ inputs.tf_version }}
           terraform_wrapper: false   # Must be false for Infracost JSON parsing
@@ -157,7 +157,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4.7.1
@@ -188,7 +188,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
@@ -233,7 +233,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Check for Infracost API key
         id: check-key
@@ -257,7 +257,7 @@ jobs:
 
       - name: Setup Terraform ${{ inputs.tf_version }}
         if: steps.check-key.outputs.present == 'true'
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ inputs.tf_version }}
           terraform_wrapper: false   # Required — Infracost needs raw terraform output
@@ -333,7 +333,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.0
+        uses: actions/checkout@v4
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4.0.1
@@ -343,7 +343,7 @@ jobs:
           role-session-name: github-actions-${{ inputs.environment }}-apply
 
       - name: Setup Terraform ${{ inputs.tf_version }}
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ inputs.tf_version }}
           terraform_wrapper: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Local Terraform state (never commit — use remote S3 backend)
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+
+# Terraform variable files often contain sensitive values
+terraform.tfvars
+*.auto.tfvars
+
+# Terraform working directories (generated on terraform init)
+**/.terraform/
+**/.terraform.lock.hcl
+
+# Plan output files (contain sensitive data)
+*.tfplan
+plan_output.txt
+apply_output.txt
+
+# Override files (local developer overrides, not for sharing)
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Crash logs
+crash.log
+crash.*.log
+
+# macOS
+.DS_Store
+
+# Editor files
+.idea/
+.vscode/
+*.swp
+*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,11 @@ terraform.tfvars
 
 # Terraform working directories (generated on terraform init)
 **/.terraform/
-**/.terraform.lock.hcl
+
+# Lock files ARE committed — they pin provider versions for reproducible builds.
+# Run: terraform -chdir=environments/<env> providers lock \
+#        -platform=linux_amd64 -platform=darwin_amd64 -platform=darwin_arm64
+# !**/.terraform.lock.hcl  (no longer ignored)
 
 # Plan output files (contain sensitive data)
 *.tfplan

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,10 +1,24 @@
-plugin "aws" {
-    enabled = true
-    version = "0.27.0"
-    source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}
+# TFLint configuration
+# Docs: https://github.com/terraform-linters/tflint
 
 plugin "terraform" {
   enabled = true
   preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.27.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+# ── Rule overrides ────────────────────────────────────────────────────────────
+
+# terraform_module_pinned_source (CKV_TF_1 / module_source_version):
+# Disabled because this repository uses local module paths (../../modules/...)
+# in a monorepo pattern. Local source references cannot and should not be pinned
+# to a version tag — the monorepo itself is the version control boundary.
+# External registry modules (if added in future) must be version-pinned.
+rule "terraform_module_pinned_source" {
+  enabled = false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ## [Unreleased]
 
+---
+
+## [1.1.0] — 2026-03-11
+
 ### Added
 - `modules/networking/security-group-module` — added `sg_unit.tftest.hcl` with six tests covering name wiring, ManagedBy tag enforcement, no default ingress, default egress protocol/CIDR, CIDR-based ingress rule count, and SG-sourced ingress rule count.
 - `modules/networking/vpc-endpoint-module` — added `vpc_endpoint_unit.tftest.hcl` with four tests covering Interface endpoint SG/subnet wiring, Gateway endpoint route-table wiring, invalid `endpoint_type` rejection via `expect_failures`, and ManagedBy tag enforcement.
@@ -59,5 +63,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 - `.tflint.hcl` — TFLint configuration with AWS plugin enabled.
 - `.gitignore` — Excludes state files, `.terraform` directories, plan outputs, and secrets.
 
-[Unreleased]: https://github.com/<org>/aws-terraform-infrastructure/compare/prod-v1.0.0...HEAD
-[1.0.0]: https://github.com/<org>/aws-terraform-infrastructure/releases/tag/prod-v1.0.0
+[Unreleased]: https://github.com/theusc6/aws-terraform-infrastructure/compare/prod-v1.1.0...HEAD
+[1.1.0]: https://github.com/theusc6/aws-terraform-infrastructure/compare/prod-v1.0.0...prod-v1.1.0
+[1.0.0]: https://github.com/theusc6/aws-terraform-infrastructure/releases/tag/prod-v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 ## [Unreleased]
 
 ### Added
+- `modules/networking/security-group-module` — added `sg_unit.tftest.hcl` with six tests covering name wiring, ManagedBy tag enforcement, no default ingress, default egress protocol/CIDR, CIDR-based ingress rule count, and SG-sourced ingress rule count.
+- `modules/networking/vpc-endpoint-module` — added `vpc_endpoint_unit.tftest.hcl` with four tests covering Interface endpoint SG/subnet wiring, Gateway endpoint route-table wiring, invalid `endpoint_type` rejection via `expect_failures`, and ManagedBy tag enforcement.
 - Full documentation suite: root README, CONTRIBUTING guide, and per-module READMEs for all nine modules.
 - `modules/alb` — Application Load Balancer module with HTTP→HTTPS redirect, configurable SSL policy, deregistration delay, and deletion protection.
 - `modules/kms` — Customer-managed KMS key module with automatic annual rotation, least-privilege default key policy, and multi-region support.
@@ -16,6 +18,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 - `CONTRIBUTING.md` — Full contribution guide covering setup, code standards, module design principles, commit conventions, and the PR process.
 
 ### Changed
+- `modules/storage` — Strengthened `https_only_policy_applied` test assertion: now decodes the bucket policy JSON and checks `Effect == "Deny"` and `Condition.Bool["aws:SecureTransport"] == "false"` rather than a trivially-true `!= null` check.
+- `modules/monitoring` — Strengthened `sns_topic_always_created` test assertion: now checks `name == "<name>-alarms"` rather than `!= null`; removed `warning_threshold_lower_than_critical` test which only asserted that `70 < 90` (no module logic was exercised).
+- `.github/workflows/module-tests.yml` — Bumped `TF_VERSION` from `1.7.5` to `1.10.5`; upgraded `actions/checkout` to `@v4` and `hashicorp/setup-terraform` to `@v3`; added `test-sg` and `test-vpc-endpoint` jobs with smart change detection; added both to the `tests-passed` gate job.
+- `.github/workflows/terraform-deploy.yml` — Bumped default `tf_version` from `1.7.5` to `1.10.5`; upgraded `actions/checkout` to `@v4` and `hashicorp/setup-terraform` to `@v3` for consistency with module tests.
+- `README.md` — Expanded Testing section: added full module test coverage table for all nine modules; added missing `terraform test` commands for compute, iam, monitoring, security-group-module, and vpc-endpoint-module.
 - `modules/compute` — Enforced IMDSv2 (`http_tokens = required`, hop limit = 1) on all launch templates; pinned ASG to specific launch template version to prevent unplanned rolling refreshes.
 - `modules/compute` — Health check type now automatically switches to `ELB` when `target_group_arns` is non-empty.
 - `modules/storage` — Added HTTPS-only bucket policy (`DenyNonTLSRequests`), `bucket_key_enabled = true` to reduce KMS API costs, and optional server access logging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,56 @@
+# Changelog
 
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Added
+- Full documentation suite: root README, CONTRIBUTING guide, and per-module READMEs for all nine modules.
+- `modules/alb` — Application Load Balancer module with HTTP→HTTPS redirect, configurable SSL policy, deregistration delay, and deletion protection.
+- `modules/kms` — Customer-managed KMS key module with automatic annual rotation, least-privilege default key policy, and multi-region support.
+- `modules/monitoring` — CloudWatch alarms (CPU warning/critical, EC2 status checks, ALB 5xx errors, unhealthy hosts, p99 response time) backed by an SNS topic.
+- `CONTRIBUTING.md` — Full contribution guide covering setup, code standards, module design principles, commit conventions, and the PR process.
+
+### Changed
+- `modules/compute` — Enforced IMDSv2 (`http_tokens = required`, hop limit = 1) on all launch templates; pinned ASG to specific launch template version to prevent unplanned rolling refreshes.
+- `modules/compute` — Health check type now automatically switches to `ELB` when `target_group_arns` is non-empty.
+- `modules/storage` — Added HTTPS-only bucket policy (`DenyNonTLSRequests`), `bucket_key_enabled = true` to reduce KMS API costs, and optional server access logging.
+- `modules/networking/vpc-module` — Added VPC Flow Logs (CloudWatch) with configurable retention; enabled by default.
+- `modules/networking/security-group-module` — Added `ingress_sg_rules` for security-group-sourced rules, separating CIDR-based and SG-based ingress.
+- `environments/prod` — One NAT Gateway per AZ for full high availability; 90-day flow log retention; KMS deletion window extended to 30 days; tighter CPU alarm thresholds (60% warning, 80% critical); ALB deletion protection enabled; HTTPS required.
+- `environments/staging` — S3 lifecycle transitions to STANDARD_IA at 30 days; 60-day flow log retention; optional HTTPS/alarm_email variables.
+- `.github/workflows/prod.yml` — Added `prod-approval` environment gate requiring manual reviewer sign-off before `terraform apply`.
+- `.tflint.hcl` — Disabled `terraform_module_pinned_source` rule for local monorepo modules.
+- `Makefile` — Added `fmt-check`, `output`, and `clean` targets; improved `destroy` with confirmation prompt.
+
+### Fixed
+- `modules/alb` — Fixed HTTP listener `default_action` to use two separate `dynamic` blocks (one for redirect, one for forward) — a single block with two actions causes a provider validation error.
+- `modules/compute` — Fixed `desired_capacity` lifecycle ignore so external autoscaling policies (target-tracking, scheduled) are not overridden on every `terraform apply`.
+- `modules/storage` — Fixed lifecycle configuration `depends_on` ordering to prevent `NoSuchLifecycleConfiguration` errors when versioning and lifecycle are modified in the same plan.
+- `modules/networking/vpc-module` — Fixed private route table count to be driven by `nat_gateway_count` rather than subnet count, preventing orphaned route tables when NAT is disabled.
+
+---
+
+## [1.0.0] — 2026-03-06
+
+### Added
+- Initial repository structure with `environments/dev`, `environments/staging`, `environments/prod`.
+- `modules/compute` — EC2 launch template and Auto Scaling Group.
+- `modules/networking/vpc-module` — VPC, public/private subnets, Internet Gateway, NAT Gateways, route tables.
+- `modules/networking/security-group-module` — Dynamic security group with CIDR and SG-source ingress rules.
+- `modules/networking/vpc-endpoint-module` — Gateway and Interface VPC endpoints.
+- `modules/iam` — IAM role with managed policy attachments, inline policies, and optional instance profile.
+- `modules/storage` — S3 bucket with versioning and KMS encryption.
+- `scripts/setup-backend.sh` — One-time bootstrap script for S3 + DynamoDB remote state backend.
+- `.github/workflows/dev.yml`, `staging.yml`, `prod.yml` — CI/CD pipelines with plan on PR and apply on tag.
+- `.github/workflows/changelog.yml` — Automatic CHANGELOG generation on merge to main.
+- `Makefile` — Developer shortcuts for init, validate, fmt, plan, apply, destroy, lint, security-scan.
+- `.tflint.hcl` — TFLint configuration with AWS plugin enabled.
+- `.gitignore` — Excludes state files, `.terraform` directories, plan outputs, and secrets.
+
+[Unreleased]: https://github.com/<org>/aws-terraform-infrastructure/compare/prod-v1.0.0...HEAD
+[1.0.0]: https://github.com/<org>/aws-terraform-infrastructure/releases/tag/prod-v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,428 @@
+# Contributing Guide
+
+Thank you for contributing to this Terraform infrastructure repository. This guide covers everything you need to know: how to set up your local environment, the standards we apply to all code, the commit message format we follow, and the pull request process.
+
+---
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Development Workflow](#development-workflow)
+- [Code Standards](#code-standards)
+- [Module Design Principles](#module-design-principles)
+- [Commit Message Convention](#commit-message-convention)
+- [Pull Request Process](#pull-request-process)
+- [Testing Your Changes](#testing-your-changes)
+- [Adding a New Module](#adding-a-new-module)
+- [Release Process](#release-process)
+
+---
+
+## Getting Started
+
+### 1. Install prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Terraform | >= 1.3.0 | [hashicorp.com/terraform](https://developer.hashicorp.com/terraform/downloads) |
+| AWS CLI | >= 2.x | [aws.amazon.com/cli](https://aws.amazon.com/cli/) |
+| TFLint | >= 0.50 | `brew install tflint` or [GitHub releases](https://github.com/terraform-linters/tflint/releases) |
+| Checkov | >= 3.x | `pip install checkov` |
+| GNU Make | >= 3.81 | Pre-installed on most Unix systems |
+
+### 2. Fork and clone
+
+```bash
+git clone https://github.com/<your-fork>/aws-terraform-infrastructure.git
+cd aws-terraform-infrastructure
+```
+
+### 3. Configure AWS credentials
+
+The easiest approach for local development is a named profile:
+
+```bash
+aws configure --profile my-dev-profile
+export AWS_PROFILE=my-dev-profile
+```
+
+For CI/CD, the workflows use OIDC and assume an IAM role — no long-lived keys.
+
+### 4. Bootstrap the state backend (once per AWS account)
+
+```bash
+export AWS_REGION=us-west-2
+export BUCKET_NAME=my-org-terraform-state
+export DYNAMO_TABLE=my-org-terraform-locks
+bash scripts/setup-backend.sh
+```
+
+---
+
+## Development Workflow
+
+```
+1. Create a branch          git checkout -b feature/describe-your-change
+2. Make changes             Edit .tf files
+3. Format                   make fmt
+4. Lint                     make lint ENV=dev
+5. Validate                 make validate ENV=dev
+6. Plan                     make plan ENV=dev
+7. Security scan            make security-scan ENV=dev
+8. Commit                   git commit -m "feat(compute): add user_data validation"
+9. Push and open PR         git push origin feature/describe-your-change
+                            gh pr create --base main
+```
+
+Never commit directly to `main`. All changes must go through a pull request.
+
+---
+
+## Code Standards
+
+### Formatting
+
+All Terraform files must be formatted with `terraform fmt`. The CI pipeline enforces this with `terraform fmt -check -recursive` and will fail unformatted PRs.
+
+```bash
+make fmt          # format all files in the repo
+make fmt-check    # check without modifying (same as CI)
+```
+
+### Naming conventions
+
+| Resource type | Convention | Example |
+|---------------|-----------|---------|
+| Resource names | `snake_case` | `aws_lb_listener.http` |
+| Variables | `snake_case` | `var.health_check_path` |
+| Outputs | `snake_case` | `output "alb_dns_name"` |
+| Local values | `snake_case` | `locals { common_tags = ... }` |
+| Module sources | Relative paths for local, pinned version for registry | `source = "../../modules/alb"` |
+| Resource labels | `"this"` for single-resource modules | `resource "aws_kms_key" "this"` |
+| Tag keys | `PascalCase` | `Environment`, `ManagedBy`, `Name` |
+
+### Tagging
+
+Every resource must have at minimum:
+
+```hcl
+tags = merge(local.common_tags, {
+  Name = "<descriptive-name>"
+})
+```
+
+where `local.common_tags` is defined as:
+
+```hcl
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+```
+
+All modules must accept a `tags = map(string)` variable (default `{}`) and merge it with `common_tags`.
+
+### Variables
+
+- Every variable must have a `description`.
+- Use `default = null` for optional values rather than empty string.
+- Add `validation` blocks for variables with constrained ranges (e.g. port numbers, retention periods).
+- Prefer specific types (`list(string)`, `object({...})`) over `any`.
+
+### Outputs
+
+- Every output must have a `description`.
+- Export everything that a caller might reasonably need — including ARN suffixes for CloudWatch dimensions.
+- When a resource is conditionally created (`count = ...`), return an empty string or `null` rather than leaving the output absent.
+
+### Comments
+
+- Use inline comments (`#`) to explain *why*, not *what*.
+- Place a comment block before any non-obvious resource explaining its purpose in the system.
+- Use the section header style for major resource groups:
+
+```hcl
+# ── Section Name ─────────────────────────────────────────────────────────────
+```
+
+---
+
+## Module Design Principles
+
+1. **Single responsibility.** Each module does one thing well. The `compute` module provisions the ASG; it does not create VPCs or IAM roles.
+
+2. **No hard-coded values.** Every environment-specific value (CIDR, instance type, replica count) must be a variable. No account IDs, region names, or ARNs should be hardcoded.
+
+3. **Safe defaults.** Defaults should be safe for development but clearly documented when they need tightening for production (e.g. `force_destroy = false`, `enable_deletion_protection = false` in dev).
+
+4. **Idempotent resources.** All resources must be safe to run multiple times. Use `create_before_destroy` where replacement would cause downtime.
+
+5. **No provider configuration inside modules.** Modules must not contain `provider` blocks. The root module (environment) configures the provider and passes it down.
+
+6. **Explicit over implicit.** Prefer passing explicit values over relying on data sources inside modules. This makes module behaviour predictable regardless of account context.
+
+7. **Every module has a README.** Use the standard template (see [Adding a New Module](#adding-a-new-module)).
+
+---
+
+## Commit Message Convention
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short summary>
+
+[optional body — wrap at 72 characters]
+
+[optional footer — BREAKING CHANGE: or Refs: #<issue>]
+```
+
+### Types
+
+| Type | When to use |
+|------|-------------|
+| `feat` | A new feature or module |
+| `fix` | A bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting (`terraform fmt`), no logic change |
+| `refactor` | Code restructuring without behaviour change |
+| `test` | Adding or modifying tests |
+| `chore` | Dependency updates, CI config, tooling |
+| `security` | Security hardening, policy changes |
+
+### Scopes
+
+Use the module or environment name: `compute`, `alb`, `kms`, `networking`, `storage`, `monitoring`, `iam`, `dev`, `staging`, `prod`, `ci`.
+
+### Examples
+
+```
+feat(alb): add optional WAF association variable
+
+fix(compute): use pinned launch template version in ASG
+
+docs(kms): add key rotation and multi-region examples to README
+
+security(storage): enforce https-only bucket policy on all buckets
+
+chore(ci): pin terraform version to 1.7.5 in workflows
+```
+
+---
+
+## Pull Request Process
+
+### Before opening a PR
+
+- [ ] `make fmt` — all files formatted
+- [ ] `make validate ENV=dev` — no validation errors
+- [ ] `make plan ENV=dev` — plan output reviewed; no unexpected changes
+- [ ] `make lint ENV=dev` — TFLint passes
+- [ ] `make security-scan ENV=dev` — Checkov passes (or suppressions are justified)
+- [ ] All new or modified modules have an up-to-date README
+
+### PR title
+
+Use the same convention as commit messages:
+
+```
+feat(monitoring): add p99 latency alarm to ALB
+```
+
+### PR description
+
+Use this template:
+
+```markdown
+## Summary
+
+<!-- 2-3 bullet points describing what changed and why -->
+
+## Changes
+
+<!-- List the files/modules changed -->
+
+## Test plan
+
+<!-- How did you verify this works? -->
+- [ ] `terraform plan` reviewed — no unexpected resource recreation
+- [ ] `terraform validate` passes
+- [ ] TFLint passes
+- [ ] Checkov passes (or suppressions documented)
+
+## Notes
+
+<!-- Anything reviewers should pay special attention to -->
+```
+
+### Review guidelines
+
+- At least **one approval** required before merging.
+- Address all review comments before merging. Mark resolved comments.
+- Squash-merge feature branches to keep `main` history clean.
+
+---
+
+## Testing Your Changes
+
+### Local plan
+
+```bash
+make plan ENV=dev
+```
+
+Review the plan output carefully. Look for unexpected `forces replacement` annotations — these indicate your change will destroy and recreate a resource, which may cause downtime.
+
+### TFLint
+
+```bash
+make lint ENV=dev
+```
+
+TFLint checks for deprecated syntax, invalid resource configurations, and AWS-specific best practice violations.
+
+### Checkov
+
+```bash
+make security-scan ENV=dev
+```
+
+Checkov performs static analysis against a library of security policies. If a finding is a false positive, suppress it with a comment and document the reason:
+
+```hcl
+#checkov:skip=CKV_AWS_18: access logging enabled via the monitoring module, not on this bucket
+resource "aws_s3_bucket" "logs" { ... }
+```
+
+### Manual integration testing
+
+For significant changes, apply to the `dev` environment and verify:
+
+1. `terraform apply` completes without errors.
+2. Resources are visible and healthy in the AWS Console.
+3. Application connectivity works end-to-end (ALB → EC2 → health check passes).
+4. CloudWatch alarms are in `OK` state.
+5. `terraform plan` after apply shows no diff.
+
+---
+
+## Adding a New Module
+
+1. **Create the directory structure:**
+
+```
+modules/<module-name>/
+├── main.tf
+├── variables.tf
+├── outputs.tf
+└── README.md
+```
+
+2. **Follow the standard layout in `main.tf`:**
+
+```hcl
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+
+# Resource definitions...
+```
+
+3. **Always include these variables:**
+
+```hcl
+variable "name"        { type = string; description = "Name prefix for all resources." }
+variable "environment" { type = string; description = "Environment name (dev/staging/prod)." }
+variable "tags"        { type = map(string); default = {}; description = "Additional tags." }
+```
+
+4. **Write the README** using this template:
+
+````markdown
+# modules/<name>
+
+One-paragraph description of what this module does and why.
+
+## Usage
+
+```hcl
+module "example" {
+  source = "../../modules/<name>"
+
+  name        = "my-app"
+  environment = "dev"
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| name | ... | `string` | — | yes |
+| environment | ... | `string` | — | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ... | ... |
+
+## Notes
+
+Any important gotchas, cost implications, or operational notes.
+````
+
+5. **Wire the module into at least one environment** (typically `dev`) to prove it works end-to-end.
+
+6. **Update** the Module Catalogue table in the root `README.md`.
+
+---
+
+## Release Process
+
+Releases are tagged manually from `main` after changes have been validated in dev and staging.
+
+```bash
+# Merge your PR to main, then:
+git checkout main
+git pull
+
+# Tag and push
+git tag prod-v1.5.0 -m "Release prod-v1.5.0"
+git push origin prod-v1.5.0
+```
+
+The production CI/CD workflow detects the tag, waits for manual approval in the `prod-approval` GitHub environment, then runs `terraform apply`.
+
+### Version numbering
+
+We use [Semantic Versioning](https://semver.org/):
+
+| Change | Version bump |
+|--------|-------------|
+| Breaking changes (resource recreation, removed outputs) | MAJOR |
+| New features, new modules, new optional variables | MINOR |
+| Bug fixes, security patches, documentation | PATCH |
+
+The same version is applied to all three environment tags:
+- `dev-v1.5.0`
+- `staging-v1.5.0`
+- `prod-v1.5.0`

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 theusc6
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,29 @@
 # Usage: make <target> ENV=<dev|staging|prod>
 #
 # Prerequisites:
-#   - Terraform >= 0.14 installed
-#   - AWS CLI configured (or OIDC role assumed)
+#   - Terraform >= 1.3.0 installed
+#   - AWS CLI configured (or OIDC role assumed via CI)
 #   - ENV variable set (defaults to dev)
 
 ENV ?= dev
 TF_DIR := environments/$(ENV)
 TF  := terraform -chdir=$(TF_DIR)
 
-.PHONY: help init validate fmt plan apply destroy lint security-scan bootstrap
+.PHONY: help bootstrap init validate fmt fmt-check plan apply destroy \
+        lint security-scan test output clean
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "  ENV defaults to 'dev'. Override with: make <target> ENV=staging"
 
+# ── Backend ───────────────────────────────────────────────────────────────────
+
 bootstrap: ## Bootstrap S3 backend and DynamoDB lock table (run once per account)
 	@bash scripts/setup-backend.sh
+
+# ── Core workflow ─────────────────────────────────────────────────────────────
 
 init: ## Initialise Terraform for the selected environment
 	$(TF) init -backend-config="key=$(ENV)/terraform.tfstate"
@@ -27,10 +32,10 @@ init: ## Initialise Terraform for the selected environment
 validate: init ## Validate Terraform configuration
 	$(TF) validate
 
-fmt: ## Format all Terraform files
+fmt: ## Format all Terraform files recursively
 	terraform fmt -recursive
 
-fmt-check: ## Check formatting without modifying files
+fmt-check: ## Check formatting without modifying files (same check as CI)
 	terraform fmt -check -recursive
 
 plan: init ## Generate and display an execution plan
@@ -43,20 +48,39 @@ apply: init ## Apply the last plan (or auto-approve if no plan file)
 		$(TF) apply -auto-approve; \
 	fi
 
-destroy: init ## Destroy all resources in the selected environment (use with caution!)
-	@echo "⚠️  WARNING: This will destroy ALL resources in the '$(ENV)' environment."
+destroy: init ## Destroy all resources in the selected environment (confirmation required)
+	@echo "WARNING: This will destroy ALL resources in the '$(ENV)' environment."
 	@read -p "Type the environment name to confirm: " confirm; \
 		[ "$$confirm" = "$(ENV)" ] || (echo "Aborted." && exit 1)
 	$(TF) destroy -auto-approve
 
+# ── Quality checks ────────────────────────────────────────────────────────────
+
 lint: ## Run TFLint against the selected environment
 	@which tflint > /dev/null || (echo "tflint not found — install from https://github.com/terraform-linters/tflint" && exit 1)
 	tflint --init
-	cd $(TF_DIR) && tflint
+	tflint --chdir=$(TF_DIR)
 
 security-scan: ## Run Checkov security scan against the selected environment
 	@which checkov > /dev/null || pip install checkov
-	checkov -d $(TF_DIR) --download-external-modules true --skip-check CKV_TF_1
+	checkov --directory $(TF_DIR) --skip-check CKV_TF_1 --compact --quiet
+
+test: ## Run Terraform native unit tests for all modules (no AWS credentials required)
+	@echo "Running module tests..."
+	@for module in \
+		modules/kms \
+		modules/storage \
+		modules/alb \
+		modules/networking/vpc-module; do \
+		echo ""; \
+		echo "==> $$module"; \
+		terraform -chdir=$$module init -backend=false > /dev/null 2>&1; \
+		terraform -chdir=$$module test -verbose || exit 1; \
+	done
+	@echo ""
+	@echo "All module tests passed."
+
+# ── Utilities ─────────────────────────────────────────────────────────────────
 
 output: init ## Print Terraform outputs for the selected environment
 	$(TF) output

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TF_DIR := environments/$(ENV)
 TF  := terraform -chdir=$(TF_DIR)
 
 .PHONY: help bootstrap init validate fmt fmt-check plan apply destroy \
-        lint security-scan test output clean
+        lint security-scan test lock output clean
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -64,6 +64,17 @@ lint: ## Run TFLint against the selected environment
 security-scan: ## Run Checkov security scan against the selected environment
 	@which checkov > /dev/null || pip install checkov
 	checkov --directory $(TF_DIR) --skip-check CKV_TF_1 --compact --quiet
+
+lock: ## Regenerate .terraform.lock.hcl for all environments (run after adding/changing providers)
+	@echo "Locking providers for all environments (linux_amd64, darwin_amd64, darwin_arm64)..."
+	@for env in dev staging prod; do \
+		echo "==> $$env"; \
+		terraform -chdir=environments/$$env providers lock \
+			-platform=linux_amd64 \
+			-platform=darwin_amd64 \
+			-platform=darwin_arm64; \
+	done
+	@echo "Done. Commit the updated .terraform.lock.hcl files."
 
 test: ## Run Terraform native unit tests for all modules (no AWS credentials required)
 	@echo "Running module tests..."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+# Terraform Demo Environment — Makefile
+# Usage: make <target> ENV=<dev|staging|prod>
+#
+# Prerequisites:
+#   - Terraform >= 0.14 installed
+#   - AWS CLI configured (or OIDC role assumed)
+#   - ENV variable set (defaults to dev)
+
+ENV ?= dev
+TF_DIR := environments/$(ENV)
+TF  := terraform -chdir=$(TF_DIR)
+
+.PHONY: help init validate fmt plan apply destroy lint security-scan bootstrap
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "  ENV defaults to 'dev'. Override with: make <target> ENV=staging"
+
+bootstrap: ## Bootstrap S3 backend and DynamoDB lock table (run once per account)
+	@bash scripts/setup-backend.sh
+
+init: ## Initialise Terraform for the selected environment
+	$(TF) init -backend-config="key=$(ENV)/terraform.tfstate"
+
+validate: init ## Validate Terraform configuration
+	$(TF) validate
+
+fmt: ## Format all Terraform files
+	terraform fmt -recursive
+
+fmt-check: ## Check formatting without modifying files
+	terraform fmt -check -recursive
+
+plan: init ## Generate and display an execution plan
+	$(TF) plan -out=$(TF_DIR)/plan.tfplan
+
+apply: init ## Apply the last plan (or auto-approve if no plan file)
+	@if [ -f $(TF_DIR)/plan.tfplan ]; then \
+		$(TF) apply $(TF_DIR)/plan.tfplan; \
+	else \
+		$(TF) apply -auto-approve; \
+	fi
+
+destroy: init ## Destroy all resources in the selected environment (use with caution!)
+	@echo "⚠️  WARNING: This will destroy ALL resources in the '$(ENV)' environment."
+	@read -p "Type the environment name to confirm: " confirm; \
+		[ "$$confirm" = "$(ENV)" ] || (echo "Aborted." && exit 1)
+	$(TF) destroy -auto-approve
+
+lint: ## Run TFLint against the selected environment
+	@which tflint > /dev/null || (echo "tflint not found — install from https://github.com/terraform-linters/tflint" && exit 1)
+	tflint --init
+	cd $(TF_DIR) && tflint
+
+security-scan: ## Run Checkov security scan against the selected environment
+	@which checkov > /dev/null || pip install checkov
+	checkov -d $(TF_DIR) --download-external-modules true --skip-check CKV_TF_1
+
+output: init ## Print Terraform outputs for the selected environment
+	$(TF) output
+
+clean: ## Remove local Terraform artefacts (.terraform dirs, plan files)
+	find . -name ".terraform" -type d -exec rm -rf {} + 2>/dev/null; true
+	find . -name "*.tfplan" -type f -delete
+	find . -name "plan_output.txt" -type f -delete
+	find . -name "apply_output.txt" -type f -delete
+	@echo "Cleaned local Terraform artefacts."

--- a/README.md
+++ b/README.md
@@ -272,13 +272,22 @@ The production workflow requires a GitHub environment named `prod-approval` with
 
 The workflows authenticate to AWS using OIDC (no long-lived keys required).
 
-| Secret | Description |
-|--------|-------------|
-| `DEV_DEPLOY_ROLE` | IAM role ARN assumed for dev deployments |
-| `STAGING_DEPLOY_ROLE` | IAM role ARN assumed for staging deployments |
-| `PROD_DEPLOY_ROLE` | IAM role ARN assumed for prod deployments |
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `DEV_DEPLOY_ROLE` | Yes | IAM role ARN assumed for dev deployments |
+| `STAGING_DEPLOY_ROLE` | Yes | IAM role ARN assumed for staging deployments |
+| `PROD_DEPLOY_ROLE` | Yes | IAM role ARN assumed for prod deployments |
+| `INFRACOST_API_KEY` | No | Infracost API key for PR cost estimates (free tier available) |
 
-Each role should be scoped to the minimum permissions needed for its environment. Using separate roles means a compromised dev pipeline cannot affect production.
+Each deploy role should be scoped to the minimum permissions needed for its environment. Using separate roles means a compromised dev pipeline cannot affect production.
+
+#### Setting up Infracost (optional but recommended)
+
+1. Sign up for a free API key at [infracost.io](https://www.infracost.io/docs/)
+2. Add `INFRACOST_API_KEY` as a repository secret in **Settings → Secrets → Actions**
+3. On the next PR, Infracost will automatically post a cost breakdown comment showing the monthly cost of every resource being added, changed, or removed
+
+If the secret is absent the cost estimate job is silently skipped — it never blocks the pipeline.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -384,16 +384,35 @@ make test
 terraform -chdir=modules/kms test -verbose
 terraform -chdir=modules/alb test -verbose
 terraform -chdir=modules/storage test -verbose
+terraform -chdir=modules/compute test -verbose
+terraform -chdir=modules/iam test -verbose
+terraform -chdir=modules/monitoring test -verbose
 terraform -chdir=modules/networking/vpc-module test -verbose
+terraform -chdir=modules/networking/security-group-module test -verbose
+terraform -chdir=modules/networking/vpc-endpoint-module test -verbose
 ```
 
 ### CI
 
 The `module-tests.yml` workflow runs automatically on every PR and push to `main` that touches `modules/**`. It detects which modules changed and only tests those — keeping CI fast. A summary job (`Module Tests Passed`) is available as a required branch protection status check.
 
+All nine modules have test coverage:
+
+| Module | Test file | Key invariants tested |
+|--------|-----------|----------------------|
+| `modules/kms` | `kms_unit.tftest.hcl` | Key rotation, deletion window validation, alias prefix |
+| `modules/storage` | `storage_unit.tftest.hcl` | Public access block, HTTPS-only policy content, versioning, lifecycle |
+| `modules/alb` | `alb_unit.tftest.hcl` | HTTPS listener gating, SSL policy, deletion protection |
+| `modules/compute` | `compute_unit.tftest.hcl` | IMDSv2 required, EBS encryption, no public IP, health check type |
+| `modules/iam` | `iam_unit.tftest.hcl` | Role name, ManagedBy tag, instance profile, policy attachment count |
+| `modules/monitoring` | `monitoring_unit.tftest.hcl` | SNS topic name, CPU thresholds, conditional ALB alarms |
+| `modules/networking/vpc-module` | `vpc_unit.tftest.hcl` | DNS defaults, subnet count, NAT gateway modes, flow logs |
+| `modules/networking/security-group-module` | `sg_unit.tftest.hcl` | No default ingress, default egress protocol, rule counts |
+| `modules/networking/vpc-endpoint-module` | `vpc_endpoint_unit.tftest.hcl` | Interface vs Gateway wiring, invalid type rejection |
+
 Each test suite validates:
-- **Variable constraints** — invalid values are correctly rejected
-- **Security defaults** — encryption, public access blocking, IMDSv2 are on by default
+- **Variable constraints** — invalid values are correctly rejected via `expect_failures`
+- **Security defaults** — encryption, public access blocking, IMDSv2 are always on
 - **Conditional resources** — e.g. HTTPS listener only created when `certificate_arn` is set
 - **Output wiring** — outputs reference the correct resource attributes
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A production-grade, opinionated Terraform monorepo for deploying a three-tier we
 - [Security Posture](#security-posture)
 - [Makefile Reference](#makefile-reference)
 - [Branching & Release Strategy](#branching--release-strategy)
+- [Testing](#testing)
 - [Contributing](#contributing)
 - [Troubleshooting](#troubleshooting)
 
@@ -271,12 +272,13 @@ The production workflow requires a GitHub environment named `prod-approval` with
 
 The workflows authenticate to AWS using OIDC (no long-lived keys required).
 
-| Secret / Variable | Description |
-|-------------------|-------------|
-| `AWS_ROLE_ARN` | IAM role ARN to assume via OIDC |
-| `AWS_REGION` | Default AWS region (e.g. `us-west-2`) |
-| `TF_STATE_BUCKET` | S3 bucket name for Terraform state |
-| `TF_LOCK_TABLE` | DynamoDB table name for state locking |
+| Secret | Description |
+|--------|-------------|
+| `DEV_DEPLOY_ROLE` | IAM role ARN assumed for dev deployments |
+| `STAGING_DEPLOY_ROLE` | IAM role ARN assumed for staging deployments |
+| `PROD_DEPLOY_ROLE` | IAM role ARN assumed for prod deployments |
+
+Each role should be scoped to the minimum permissions needed for its environment. Using separate roles means a compromised dev pipeline cannot affect production.
 
 ---
 
@@ -351,6 +353,28 @@ main  ────────────────────────�
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide, including code style, commit message conventions, module design principles, and the pull request checklist.
+
+---
+
+## Testing
+
+This repository uses the [Terraform native test framework](https://developer.hashicorp.com/terraform/language/tests) (Terraform >= 1.6). Tests live alongside each module and use mock providers — no AWS credentials or live resources are required.
+
+```bash
+# Run all tests for a module
+terraform -chdir=modules/kms test -verbose
+terraform -chdir=modules/alb test -verbose
+terraform -chdir=modules/storage test -verbose
+terraform -chdir=modules/networking/vpc-module test -verbose
+```
+
+Each test suite validates:
+- **Variable constraints** — invalid values are correctly rejected
+- **Security defaults** — encryption, public access blocking, IMDSv2 are on by default
+- **Conditional resources** — e.g. HTTPS listener only created when `certificate_arn` is set
+- **Output wiring** — outputs reference the correct resource attributes
+
+See [`tests/README.md`](tests/README.md) for the full testing guide and instructions for writing integration tests.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,82 +1,396 @@
-# Terraform Infrastructure Repository
-This repository contains the Terraform configurations for setting up and managing our cloud infrastructure. Each environment (production, staging, development) has its own set of configurations, ensuring isolation and easy management of resources.
+# AWS Terraform Infrastructure
 
-## Directory Structure
+A production-grade, opinionated Terraform monorepo for deploying a three-tier web application stack on AWS. The repository ships a complete set of reusable modules, three fully-configured environments (dev / staging / prod), and a GitHub Actions CI/CD pipeline that automatically plans on every pull request and applies on environment-specific git tags.
+
+---
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Repository Layout](#repository-layout)
+- [Module Catalogue](#module-catalogue)
+- [Environment Comparison](#environment-comparison)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [CI/CD Pipeline](#cicd-pipeline)
+- [Security Posture](#security-posture)
+- [Makefile Reference](#makefile-reference)
+- [Branching & Release Strategy](#branching--release-strategy)
+- [Contributing](#contributing)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Architecture Overview
+
 ```
-terraform-repo/
+                          ┌─────────────────────────────────────────────────┐
+                          │                    AWS Account                   │
+                          │                                                  │
+                          │   ┌──────────────────────────────────────────┐  │
+                          │   │                    VPC                    │  │
+                          │   │  ┌─────────────────────────────────────┐ │  │
+                          │   │  │         Public Subnets (AZa/b/c)    │ │  │
+                          │   │  │  ┌──────────┐   ┌───────────────┐  │ │  │
+Internet ─────────────────┼───┼──┤  │   ALB    │   │  NAT Gateway  │  │ │  │
+                          │   │  │  └────┬─────┘   └───────────────┘  │ │  │
+                          │   │  └───────┼─────────────────────────────┘ │  │
+                          │   │          │                                  │  │
+                          │   │  ┌───────┼─────────────────────────────┐ │  │
+                          │   │  │       │  Private Subnets (AZa/b/c)  │ │  │
+                          │   │  │  ┌────▼────────────────────────┐   │ │  │
+                          │   │  │  │   Auto Scaling Group         │   │ │  │
+                          │   │  │  │   EC2 instances (IMDSv2)     │   │ │  │
+                          │   │  │  │   EBS gp3, KMS-encrypted     │   │ │  │
+                          │   │  │  └─────────────────────────────┘   │ │  │
+                          │   │  └─────────────────────────────────────┘ │  │
+                          │   └──────────────────────────────────────────┘  │
+                          │                                                  │
+                          │   ┌──────────┐  ┌──────────┐  ┌─────────────┐  │
+                          │   │    S3    │  │   KMS    │  │ CloudWatch  │  │
+                          │   │ (storage)│  │  (keys)  │  │ + SNS alarms│  │
+                          │   └──────────┘  └──────────┘  └─────────────┘  │
+                          │                                                  │
+                          │   ┌──────────────────────────────────────────┐  │
+                          │   │       S3 + DynamoDB (Terraform State)    │  │
+                          │   └──────────────────────────────────────────┘  │
+                          └─────────────────────────────────────────────────┘
+```
+
+**Data flow:**
+1. HTTPS traffic enters via the internet-facing ALB in the public subnets.
+2. The ALB terminates TLS and forwards to EC2 instances running in private subnets.
+3. EC2 instances reach the internet (for package updates, etc.) via NAT Gateways.
+4. Application data is persisted to KMS-encrypted S3 buckets.
+5. CloudWatch alarms publish to SNS for operational alerting.
+6. VPC Flow Logs capture all traffic metadata for security auditing.
+
+---
+
+## Repository Layout
+
+```
+aws-terraform-infrastructure/
+├── .github/
+│   └── workflows/
+│       ├── changelog.yml          # Auto-generate CHANGELOG on main merges
+│       ├── dev.yml                # Plan + apply pipeline for dev environment
+│       ├── staging.yml            # Plan + apply pipeline for staging environment
+│       └── prod.yml               # Plan + apply pipeline for prod (gated)
 │
 ├── environments/
-│   ├── prod/
-│   ├── staging/
-│   └── dev/
+│   ├── dev/                       # Development environment (low cost, no HA)
+│   │   ├── backend.tf
+│   │   ├── main.tf
+│   │   ├── outputs.tf
+│   │   ├── providers.tf
+│   │   ├── variables.tf
+│   │   └── terraform.tfvars.example
+│   ├── staging/                   # Staging environment (mirrors prod topology)
+│   │   └── ...
+│   └── prod/                      # Production environment (HA, hardened)
+│       └── ...
 │
 ├── modules/
-│   ├── compute/
-│   ├── networking/
-│   └── storage/
-
+│   ├── alb/                       # Application Load Balancer + target group + listeners
+│   ├── compute/                   # Launch template + Auto Scaling Group
+│   ├── iam/                       # IAM roles, policy attachments, instance profiles
+│   ├── kms/                       # Customer-managed KMS key + alias
+│   ├── monitoring/                # CloudWatch alarms + SNS topic
+│   ├── storage/                   # S3 bucket with encryption, versioning, lifecycle
+│   └── networking/
+│       ├── vpc-module/            # VPC, subnets, IGW, NAT GWs, route tables, flow logs
+│       ├── security-group-module/ # Security groups with dynamic rules
+│       └── vpc-endpoint-module/   # VPC endpoints (Gateway + Interface)
+│
+├── scripts/
+│   └── setup-backend.sh           # Bootstrap Terraform remote state backend (run once)
+│
+├── .gitignore
+├── .tflint.hcl                    # TFLint configuration
+├── CHANGELOG.md
+├── CONTRIBUTING.md
+├── Makefile                       # Developer workflow shortcuts
+└── README.md
 ```
-- environments/: Contains configurations specific to each environment. Each has its own state file.
-- modules/: Contains reusable Terraform modules used across different environments.
+
+---
+
+## Module Catalogue
+
+| Module | Purpose | Key Resources |
+|--------|---------|---------------|
+| [`modules/kms`](modules/kms/README.md) | Customer-managed encryption keys | `aws_kms_key`, `aws_kms_alias` |
+| [`modules/networking/vpc-module`](modules/networking/vpc-module/README.md) | VPC, subnets, routing, flow logs | VPC, subnets, IGW, NAT GW, route tables |
+| [`modules/networking/security-group-module`](modules/networking/security-group-module/README.md) | Dynamic security groups | `aws_security_group` |
+| [`modules/networking/vpc-endpoint-module`](modules/networking/vpc-endpoint-module/README.md) | Private connectivity to AWS services | `aws_vpc_endpoint` |
+| [`modules/iam`](modules/iam/README.md) | IAM roles and instance profiles | `aws_iam_role`, `aws_iam_instance_profile` |
+| [`modules/alb`](modules/alb/README.md) | Application Load Balancer | ALB, target group, HTTP/HTTPS listeners |
+| [`modules/compute`](modules/compute/README.md) | Auto-scaling EC2 fleet | Launch template, ASG, IMDSv2, gp3 EBS |
+| [`modules/storage`](modules/storage/README.md) | Secure S3 storage | S3 bucket, versioning, lifecycle, KMS |
+| [`modules/monitoring`](modules/monitoring/README.md) | Operational observability | SNS, CloudWatch alarms |
+
+---
+
+## Environment Comparison
+
+| Feature | dev | staging | prod |
+|---------|-----|---------|------|
+| Instance type | `t3.micro` | `t3.small` | `t3.medium` |
+| ASG capacity | 1–2 (desired 1) | 1–4 (desired 2) | 2–6 (desired 2) |
+| NAT Gateways | 1 (shared) | 1 (shared) | 1 per AZ (HA) |
+| Availability zones | 2 | 2 | 3 |
+| HTTPS / TLS | Optional | Optional | Required |
+| ALB deletion protection | No | No | Yes |
+| KMS deletion window | 7 days | 7 days | 30 days |
+| Flow log retention | 30 days | 60 days | 90 days |
+| S3 lifecycle transitions | — | STANDARD_IA at 30d | GLACIER at 90d |
+| CPU warning threshold | 70% | 70% | 60% |
+| CPU critical threshold | 90% | 90% | 80% |
+| Manual apply approval | No | No | Yes |
+
+---
 
 ## Prerequisites
-- Terraform (version >= 0.14)
-- Appropriate cloud provider CLI and credentials set up. For AWS, AWS CLI and configured credentials.
 
-## Getting Started
-### 1. Clone the Repo
-```
-git clone <repository-url>
-```
-### 2. Navigate to an Environment
-```
-cd terraform-repo/environments/<env>  # Replace <env> with dev, staging, or prod
-```
-### 3. Create a New Branch
-```
-git checkout -b feature-<feature-name> # For example: git checkout -b feature-add-s3
-```
-### 4. Make Changes
-Modify the Terraform configuration files as necessary for your infrastructure needs.
+| Tool | Minimum Version | Notes |
+|------|-----------------|-------|
+| [Terraform](https://developer.hashicorp.com/terraform/downloads) | 1.3.0 | Enforced by `required_version` |
+| [AWS CLI](https://aws.amazon.com/cli/) | 2.x | Must be configured with appropriate credentials |
+| [TFLint](https://github.com/terraform-linters/tflint) | 0.50+ | For local linting (`make lint`) |
+| [Checkov](https://www.checkov.io/) | 3.x | For security scanning (`make security-scan`) |
+| [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | For Makefile targets |
+| [gh CLI](https://cli.github.com/) | 2.x | For pull request creation |
 
-### 5. Commit & Push Your Changes
-```
-git add .
-git commit -m "Your descriptive commit message"
-git push origin feature-<feature-name>
-```
-### 6. Open a Pull Request
-```
-gh pr create --base main --head feature-<feature-name> --title "Your PR title" --body "Description of the changes."
-```
-### 7. Merge Pull Request
-Once your PR is approved, merge it to the main branch. Any merge into main will automatically deploy to the development environment.
+**AWS Permissions:** The deploying identity (user or role) needs IAM, EC2, VPC, S3, KMS, CloudWatch, SNS, and ALB permissions. Use `AdministratorAccess` for initial bootstrapping and lock down to least-privilege policies for ongoing CI/CD.
 
-### 8. Tag for Staging or Production
-When you decide the main branch's state is ready for staging or production, create a tag:
-```
-git checkout main
-git pull
-git tag <env>-vX.Y.Z # For example: git tag staging-v0.1.1
-git push origin <env>-vX.Y.Z
-```
-Note: Adjust <env> to staging or prod depending on where you want the deployment. Once this tag is pushed, the CI/CD workflow will detect this tag and initiate the deployment process to the designated environment.
+---
 
-### 9. Github Actions CI/CD
-GitHub Actions will automatically run terraform init, terraform plan, and, upon detecting an environment-specific tag, terraform apply.
+## Quick Start
 
-## Best Practices
-- **Do Not Hardcode**: Use variables for any values that might change.
-- **Document Changes**: Comment configurations and commit messages should be descriptive.
-- **Use Version Constraints**: Specify version constraints for providers.
-- **Never Store Sensitive Data**: Do not hard-code sensitive data in configurations.
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/<org>/aws-terraform-infrastructure.git
+cd aws-terraform-infrastructure
+```
+
+### 2. Bootstrap the remote state backend (once per AWS account)
+
+The remote state uses S3 for storage and DynamoDB for state locking. Run this script once before any `terraform init`:
+
+```bash
+export AWS_REGION=us-west-2
+export BUCKET_NAME=my-org-terraform-state
+export DYNAMO_TABLE=my-org-terraform-locks
+
+bash scripts/setup-backend.sh
+```
+
+Then update the `backend.tf` files in each environment directory with your chosen bucket name and DynamoDB table name.
+
+### 3. Configure environment variables
+
+```bash
+cp environments/dev/terraform.tfvars.example environments/dev/terraform.tfvars
+# Edit the file — at minimum, set your AWS account_id and region
+```
+
+### 4. Initialise Terraform
+
+```bash
+make init ENV=dev
+```
+
+### 5. Validate and plan
+
+```bash
+make validate ENV=dev
+make plan ENV=dev
+```
+
+### 6. Apply (dev/staging only — prod uses the CI/CD approval gate)
+
+```bash
+make apply ENV=dev
+```
+
+---
+
+## CI/CD Pipeline
+
+All three workflows follow the same structure:
+
+```
+Pull Request opened/updated
+        │
+        ▼
+  terraform fmt --check     ← fails if files are unformatted
+        │
+        ▼
+  terraform init
+        │
+        ▼
+  terraform validate        ← syntax and schema check
+        │
+        ▼
+  terraform plan            ← plan output posted as PR artefact
+        │
+        ▼
+  checkov scan              ← fails on HIGH/CRITICAL severity findings
+        │
+        ▼
+  tflint                    ← AWS-specific static analysis
+        │
+        ▼
+  [PR merged / environment tag pushed]
+        │
+        ├── dev-* tag or PR to main → terraform apply (dev, auto-approved)
+        ├── staging-* tag           → terraform apply (staging, auto-approved)
+        └── prod-* tag              → manual approval → terraform apply (prod)
+```
+
+### Deployment tags
+
+| Environment | Tag pattern | Example |
+|-------------|-------------|---------|
+| dev | `dev-vX.Y.Z` | `dev-v1.4.2` |
+| staging | `staging-vX.Y.Z` | `staging-v1.4.2` |
+| prod | `prod-vX.Y.Z` | `prod-v1.4.2` |
+
+```bash
+# Promote to production
+git checkout main && git pull
+git tag prod-v1.4.2
+git push origin prod-v1.4.2
+```
+
+The production workflow requires a GitHub environment named `prod-approval` with at least one required reviewer configured before the `terraform apply` job runs.
+
+### Required GitHub Secrets
+
+The workflows authenticate to AWS using OIDC (no long-lived keys required).
+
+| Secret / Variable | Description |
+|-------------------|-------------|
+| `AWS_ROLE_ARN` | IAM role ARN to assume via OIDC |
+| `AWS_REGION` | Default AWS region (e.g. `us-west-2`) |
+| `TF_STATE_BUCKET` | S3 bucket name for Terraform state |
+| `TF_LOCK_TABLE` | DynamoDB table name for state locking |
+
+---
+
+## Security Posture
+
+This repository is designed to align with the **CIS AWS Foundations Benchmark** and AWS security best practices:
+
+| Control | Implementation |
+|---------|---------------|
+| Encryption at rest | All S3 buckets and EBS volumes use customer-managed KMS keys |
+| Encryption in transit | S3 bucket policy denies non-TLS requests; ALB redirects HTTP→HTTPS in staging/prod |
+| Least-privilege IAM | Explicit trust policies; no wildcard resource in inline policies |
+| Instance metadata | IMDSv2 enforced on all EC2 instances (hop limit = 1, token required) |
+| No public EC2 | Instances launch in private subnets with `map_public_ip_on_launch = false` |
+| VPC Flow Logs | Enabled by default in all environments (CloudWatch Logs) |
+| State backend security | S3 bucket versioning + KMS encryption + DynamoDB state locking |
+| KMS key rotation | Annual automatic rotation enabled on all keys |
+| ALB deletion protection | Enabled in production |
+| Public S3 access | Blocked at the bucket level (all four block settings) |
+| Security scanning | Checkov runs on every pull request; TFLint catches provider-specific issues |
+
+---
+
+## Makefile Reference
+
+```
+make help                    Show all available targets
+
+make bootstrap               Bootstrap S3 backend and DynamoDB lock table (run once)
+
+make init        ENV=<env>   terraform init for the selected environment
+make validate    ENV=<env>   terraform validate (implies init)
+make fmt                     Format all .tf files recursively
+make fmt-check               Check formatting without modifying files
+
+make plan        ENV=<env>   Generate execution plan (saved to environments/<env>/plan.tfplan)
+make apply       ENV=<env>   Apply the saved plan (or auto-approve if no plan file exists)
+make destroy     ENV=<env>   Destroy all resources in the selected environment (confirmation required)
+
+make lint        ENV=<env>   Run TFLint
+make security-scan ENV=<env> Run Checkov security scan
+
+make output      ENV=<env>   Print terraform outputs
+make clean                   Remove all local .terraform dirs and plan files
+```
+
+`ENV` defaults to `dev`. Override with `make plan ENV=staging`.
+
+---
+
+## Branching & Release Strategy
+
+```
+main  ──────────────────────────────────────────────────────────────────▶
+       │  merge PR          tag dev-v1.2.0    tag staging-v1.2.0    tag prod-v1.2.0
+       │  ──────────────▶   ──────────────▶   ──────────────────▶   ──────────────▶
+       │  auto-deploy dev   auto-deploy dev   auto-deploy staging   manual → prod
+       │
+       └─ feature/my-change  (short-lived branch)
+```
+
+1. **Branch** off `main` for every change.
+2. **Open a PR** — CI runs format, plan, lint, and security scan automatically.
+3. **Merge to main** — triggers an automatic dev deployment.
+4. **Tag** `staging-vX.Y.Z` to promote to staging.
+5. **Tag** `prod-vX.Y.Z` to kick off the production workflow (requires manual approval from a reviewer in the `prod-approval` GitHub environment).
+
+> Protect the `main` branch with required PR reviews and required status checks.
+
+---
 
 ## Contributing
-1. Create a new branch for your changes.
-2. Make changes and test them thoroughly.
-3. Open a pull request, and request reviews from the team once all checks are complete and passed.
 
-Note: 
-Merging a PR into main automatically deploys to dev.
-Tagging a commit as staging-vX.Y.Z would deploy that commit to the staging environment.
-Tagging a commit as prod-vX.Y.Z would deploy that commit to the production environment.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide, including code style, commit message conventions, module design principles, and the pull request checklist.
+
+---
+
+## Troubleshooting
+
+### `Error: Backend configuration changed`
+
+Run `terraform init -reconfigure` if you changed backend settings:
+
+```bash
+make init ENV=dev
+# or directly:
+terraform -chdir=environments/dev init -reconfigure
+```
+
+### `Error: Failed to lock state`
+
+Another process holds the DynamoDB lock. Check the DynamoDB table for a stale `LockID` item and delete it manually if the previous run is confirmed dead.
+
+### `Error: AccessDenied when calling KMS`
+
+The IAM role used by Terraform must have `kms:GenerateDataKey` and `kms:Decrypt` on the target key. Verify the key policy includes the deploying role's ARN under the `AllowKeyAdministration` statement.
+
+### `checkov` returns false positives
+
+Add an inline suppression comment above the resource:
+
+```hcl
+#checkov:skip=CKV_AWS_XXXX: <reason for skipping>
+resource "aws_example" "this" { ... }
+```
+
+For project-wide skips, add the check ID to the `--skip-check` list in the relevant workflow YAML file.
+
+### Formatting check fails in CI
+
+Run `make fmt` locally before pushing:
+
+```bash
+make fmt
+git add -u
+git commit -m "style: run terraform fmt"
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # AWS Terraform Infrastructure
 
+![Module Tests](https://github.com/theusc6/aws-terraform-infrastructure/actions/workflows/module-tests.yml/badge.svg)
+![Drift Detection](https://github.com/theusc6/aws-terraform-infrastructure/actions/workflows/drift-detection.yml/badge.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.3.0-7B42BC)](https://developer.hashicorp.com/terraform)
+
 A production-grade, opinionated Terraform monorepo for deploying a three-tier web application stack on AWS. The repository ships a complete set of reusable modules, three fully-configured environments (dev / staging / prod), and a GitHub Actions CI/CD pipeline that automatically plans on every pull request and applies on environment-specific git tags.
 
 ---
@@ -367,15 +372,24 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution guide, includin
 
 ## Testing
 
-This repository uses the [Terraform native test framework](https://developer.hashicorp.com/terraform/language/tests) (Terraform >= 1.6). Tests live alongside each module and use mock providers — no AWS credentials or live resources are required.
+This repository uses the [Terraform native test framework](https://developer.hashicorp.com/terraform/language/tests) (Terraform >= 1.6). Tests live alongside each module and use mock providers — **no AWS credentials or live resources required**.
+
+### Run locally
 
 ```bash
-# Run all tests for a module
+# Run all module tests at once
+make test
+
+# Run tests for a specific module
 terraform -chdir=modules/kms test -verbose
 terraform -chdir=modules/alb test -verbose
 terraform -chdir=modules/storage test -verbose
 terraform -chdir=modules/networking/vpc-module test -verbose
 ```
+
+### CI
+
+The `module-tests.yml` workflow runs automatically on every PR and push to `main` that touches `modules/**`. It detects which modules changed and only tests those — keeping CI fast. A summary job (`Module Tests Passed`) is available as a required branch protection status check.
 
 Each test suite validates:
 - **Variable constraints** — invalid values are correctly rejected

--- a/environments/dev/.terraform.lock.hcl
+++ b/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -12,6 +12,23 @@ locals {
   }
 }
 
+# Resolve the latest Amazon Linux 2023 AMI for the target region automatically.
+# This avoids hardcoded AMI IDs that become stale and are region-specific.
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
 # ── Networking ────────────────────────────────────────────────────────────────
 
 module "vpc" {
@@ -54,13 +71,16 @@ module "app_sg" {
   tags = local.tags
 }
 
-# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic
+# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic.
+# Gateway endpoints require route table associations (not security groups).
 module "vpc_endpoint_s3" {
   source = "../../modules/networking/vpc-endpoint-module"
 
-  vpc_id        = module.vpc.vpc_id
-  service_name  = "com.amazonaws.${var.region}.s3"
-  endpoint_type = "Gateway"
+  vpc_id          = module.vpc.vpc_id
+  service_name    = "com.amazonaws.${var.region}.s3"
+  endpoint_type   = "Gateway"
+  route_table_ids = module.vpc.private_route_table_ids
+  tags            = local.tags
 }
 
 # ── IAM ──────────────────────────────────────────────────────────────────────
@@ -117,7 +137,7 @@ module "app_compute" {
   name        = "${local.environment}-app"
   environment = local.environment
 
-  ami_id               = var.ami_id
+  ami_id               = data.aws_ami.amazon_linux_2023.id
   instance_type        = "t3.micro"
   subnet_ids           = module.vpc.private_subnet_ids
   security_group_ids   = [module.app_sg.security_group_id]

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -7,13 +7,14 @@ locals {
   private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
 
   tags = {
-    Project = "demo"
-    Owner   = "platform-team"
+    Project     = "demo"
+    Environment = local.environment
+    Owner       = "platform-team"
   }
 }
 
-# Resolve the latest Amazon Linux 2023 AMI for the target region automatically.
-# This avoids hardcoded AMI IDs that become stale and are region-specific.
+# Resolve the latest Amazon Linux 2023 AMI for the target region at plan time.
+# This avoids hardcoded AMI IDs that are region-specific and quickly become stale.
 data "aws_ami" "amazon_linux_2023" {
   most_recent = true
   owners      = ["amazon"]
@@ -29,6 +30,20 @@ data "aws_ami" "amazon_linux_2023" {
   }
 }
 
+# ── KMS ───────────────────────────────────────────────────────────────────────
+# A single customer-managed key covers all encryption in this environment
+# (S3 objects, EBS volumes). Using one key per environment keeps IAM policies
+# simple while still giving us full audit control via CloudTrail.
+
+module "kms" {
+  source = "../../modules/kms"
+
+  alias_name   = "${local.environment}-app"
+  description  = "Customer-managed key for ${local.environment} S3 and EBS encryption"
+  environment  = local.environment
+  tags         = local.tags
+}
+
 # ── Networking ────────────────────────────────────────────────────────────────
 
 module "vpc" {
@@ -40,15 +55,18 @@ module "vpc" {
   public_subnet_cidrs  = local.public_subnet_cidrs
   private_subnet_cidrs = local.private_subnet_cidrs
   enable_nat_gateway   = true
-  single_nat_gateway   = true # Single NAT GW keeps dev costs low
+  single_nat_gateway   = true  # Single NAT GW keeps dev costs low; not HA
+  enable_flow_logs     = true
   tags                 = local.tags
 }
 
-module "app_sg" {
+# ALB security group — allows inbound HTTP from anywhere.
+# No HTTPS in dev (no ACM certificate required), so only port 80 is opened.
+module "alb_sg" {
   source = "../../modules/networking/security-group-module"
 
-  name        = "${local.environment}-app-sg"
-  description = "Security group for ${local.environment} application servers"
+  name        = "${local.environment}-alb-sg"
+  description = "Security group for the ${local.environment} Application Load Balancer"
   vpc_id      = module.vpc.vpc_id
 
   ingress_rules = [
@@ -56,23 +74,41 @@ module "app_sg" {
       from_port   = 80
       to_port     = 80
       protocol    = "tcp"
-      cidr_blocks = [local.vpc_cidr]
-      description = "HTTP from within the VPC"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTP from the internet"
     },
-    {
-      from_port   = 443
-      to_port     = 443
-      protocol    = "tcp"
-      cidr_blocks = [local.vpc_cidr]
-      description = "HTTPS from within the VPC"
-    }
   ]
 
   tags = local.tags
 }
 
-# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic.
-# Gateway endpoints require route table associations (not security groups).
+# Application security group — only allows traffic from the ALB.
+# No direct internet access to the instances, even on port 80.
+# This uses the ingress_sg_rules variable (added in the last hardening pass)
+# to reference the ALB SG as the source rather than a CIDR range.
+module "app_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "${local.environment}-app-sg"
+  description = "Security group for ${local.environment} application servers"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_sg_rules = [
+    {
+      from_port                = 80
+      to_port                  = 80
+      protocol                 = "tcp"
+      source_security_group_id = module.alb_sg.security_group_id
+      description              = "HTTP from the ALB only"
+    },
+  ]
+
+  tags = local.tags
+}
+
+# S3 VPC Gateway Endpoint — routes S3 traffic over the AWS backbone instead of
+# through the NAT gateway. This eliminates NAT processing charges for S3 traffic,
+# which can be significant in data-heavy workloads.
 module "vpc_endpoint_s3" {
   source = "../../modules/networking/vpc-endpoint-module"
 
@@ -81,6 +117,29 @@ module "vpc_endpoint_s3" {
   endpoint_type   = "Gateway"
   route_table_ids = module.vpc.private_route_table_ids
   tags            = local.tags
+}
+
+# ── Load Balancing ────────────────────────────────────────────────────────────
+
+module "alb" {
+  source = "../../modules/alb"
+
+  name        = "${local.environment}-app"
+  environment = local.environment
+  vpc_id      = module.vpc.vpc_id
+
+  # ALB must be in public subnets to receive internet traffic.
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = [module.alb_sg.security_group_id]
+
+  # No ACM certificate in dev — HTTP only.
+  # Set certificate_arn to enable HTTPS + automatic HTTP→HTTPS redirect.
+  certificate_arn = null
+
+  health_check_path          = "/health"
+  enable_deletion_protection = false  # Allow terraform destroy in dev
+
+  tags = local.tags
 }
 
 # ── IAM ──────────────────────────────────────────────────────────────────────
@@ -101,7 +160,9 @@ module "ec2_role" {
   })
 
   policy_arns = [
+    # SSM Session Manager — allows shell access without a bastion host or open SSH port
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    # CloudWatch agent — enables detailed memory, disk, and custom metrics
     "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
   ]
 
@@ -111,12 +172,35 @@ module "ec2_role" {
 
 # ── Storage ───────────────────────────────────────────────────────────────────
 
+# Dedicated bucket for S3 server access logs.
+# Using a separate bucket prevents recursive logging and keeps log data isolated.
+module "access_logs_bucket" {
+  source = "../../modules/storage"
+
+  bucket_name        = "${local.environment}-access-logs-${var.account_id}"
+  environment        = local.environment
+  versioning_enabled = false  # Access logs grow large; versioning is not needed here
+  kms_key_arn        = module.kms.key_arn
+
+  lifecycle_rules = [
+    {
+      id      = "expire-logs"
+      enabled = true
+      expiration_days = 30  # Keep 30 days of access logs in dev
+    }
+  ]
+
+  tags = local.tags
+}
+
 module "app_storage" {
   source = "../../modules/storage"
 
   bucket_name        = "${local.environment}-app-storage-${var.account_id}"
   environment        = local.environment
   versioning_enabled = true
+  kms_key_arn        = module.kms.key_arn
+  logging_bucket_id  = module.access_logs_bucket.bucket_id
 
   lifecycle_rules = [
     {
@@ -137,15 +221,36 @@ module "app_compute" {
   name        = "${local.environment}-app"
   environment = local.environment
 
-  ami_id               = data.aws_ami.amazon_linux_2023.id
-  instance_type        = "t3.micro"
-  subnet_ids           = module.vpc.private_subnet_ids
-  security_group_ids   = [module.app_sg.security_group_id]
-  iam_instance_profile = module.ec2_role.instance_profile_name
+  ami_id                    = data.aws_ami.amazon_linux_2023.id
+  instance_type             = "t3.micro"
+  kms_key_arn               = module.kms.key_arn
+  subnet_ids                = module.vpc.private_subnet_ids
+  security_group_ids        = [module.app_sg.security_group_id]
+  iam_instance_profile      = module.ec2_role.instance_profile_name
+  target_group_arns         = [module.alb.target_group_arn]
+  health_check_grace_period = 120
 
   min_size         = 1
   max_size         = 2
   desired_capacity = 1
+
+  tags = local.tags
+}
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  name                    = "${local.environment}-app"
+  environment             = local.environment
+  autoscaling_group_name  = module.app_compute.autoscaling_group_name
+  alb_arn_suffix          = module.alb.alb_arn_suffix
+  target_group_arn_suffix = module.alb.target_group_arn_suffix
+
+  # Set alarm_email to receive notifications. In production, consider routing
+  # to PagerDuty or Opsgenie via an SNS→Lambda integration instead.
+  alarm_email = null
 
   tags = local.tags
 }

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -1,8 +1,131 @@
-resource "aws_account_alternate_contact" "security" {
-  alternate_contact_type = "SECURITY"
+locals {
+  environment = "dev"
 
-  name              = "Test Name13"
-  title             = "Test Title2"
-  phone_number      = "+1234567890"
-  email_address     = "testemail@test.com"
+  vpc_cidr             = "10.0.0.0/16"
+  azs                  = ["${var.region}a", "${var.region}b"]
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+
+  tags = {
+    Project = "demo"
+    Owner   = "platform-team"
+  }
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+module "vpc" {
+  source = "../../modules/networking/vpc-module"
+
+  environment          = local.environment
+  vpc_cidr             = local.vpc_cidr
+  azs                  = local.azs
+  public_subnet_cidrs  = local.public_subnet_cidrs
+  private_subnet_cidrs = local.private_subnet_cidrs
+  enable_nat_gateway   = true
+  single_nat_gateway   = true # Single NAT GW keeps dev costs low
+  tags                 = local.tags
+}
+
+module "app_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "${local.environment}-app-sg"
+  description = "Security group for ${local.environment} application servers"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_rules = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = [local.vpc_cidr]
+      description = "HTTP from within the VPC"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [local.vpc_cidr]
+      description = "HTTPS from within the VPC"
+    }
+  ]
+
+  tags = local.tags
+}
+
+# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic
+module "vpc_endpoint_s3" {
+  source = "../../modules/networking/vpc-endpoint-module"
+
+  vpc_id        = module.vpc.vpc_id
+  service_name  = "com.amazonaws.${var.region}.s3"
+  endpoint_type = "Gateway"
+}
+
+# ── IAM ──────────────────────────────────────────────────────────────────────
+
+module "ec2_role" {
+  source = "../../modules/iam"
+
+  role_name   = "${local.environment}-ec2-role"
+  description = "IAM role for ${local.environment} EC2 instances"
+
+  trust_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+  ]
+
+  create_instance_profile = true
+  tags                    = local.tags
+}
+
+# ── Storage ───────────────────────────────────────────────────────────────────
+
+module "app_storage" {
+  source = "../../modules/storage"
+
+  bucket_name        = "${local.environment}-app-storage-${var.account_id}"
+  environment        = local.environment
+  versioning_enabled = true
+
+  lifecycle_rules = [
+    {
+      id      = "expire-old-noncurrent-versions"
+      enabled = true
+      noncurrent_version_expiration_days = 30
+    }
+  ]
+
+  tags = local.tags
+}
+
+# ── Compute ───────────────────────────────────────────────────────────────────
+
+module "app_compute" {
+  source = "../../modules/compute"
+
+  name        = "${local.environment}-app"
+  environment = local.environment
+
+  ami_id               = var.ami_id
+  instance_type        = "t3.micro"
+  subnet_ids           = module.vpc.private_subnet_ids
+  security_group_ids   = [module.app_sg.security_group_id]
+  iam_instance_profile = module.ec2_role.instance_profile_name
+
+  min_size         = 1
+  max_size         = 2
+  desired_capacity = 1
+
+  tags = local.tags
 }

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -1,1 +1,44 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
 
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = module.vpc.private_subnet_ids
+}
+
+output "app_security_group_id" {
+  description = "Security group ID for the application layer"
+  value       = module.app_sg.security_group_id
+}
+
+output "app_storage_bucket" {
+  description = "Application S3 bucket name"
+  value       = module.app_storage.bucket_id
+}
+
+output "app_storage_bucket_arn" {
+  description = "Application S3 bucket ARN"
+  value       = module.app_storage.bucket_arn
+}
+
+output "ec2_role_arn" {
+  description = "IAM role ARN for EC2 instances"
+  value       = module.ec2_role.role_arn
+}
+
+output "autoscaling_group_name" {
+  description = "Name of the application Auto Scaling Group"
+  value       = module.app_compute.autoscaling_group_name
+}
+
+output "vpc_endpoint_s3_id" {
+  description = "ID of the S3 VPC Gateway Endpoint"
+  value       = module.vpc_endpoint_s3.vpc_endpoint_id
+}

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -1,44 +1,112 @@
+# ── Network Outputs ───────────────────────────────────────────────────────────
+
 output "vpc_id" {
-  description = "The ID of the VPC"
+  description = "The ID of the VPC."
   value       = module.vpc.vpc_id
 }
 
 output "public_subnet_ids" {
-  description = "IDs of the public subnets"
+  description = "IDs of the public subnets (ALB, NAT gateways)."
   value       = module.vpc.public_subnet_ids
 }
 
 output "private_subnet_ids" {
-  description = "IDs of the private subnets"
+  description = "IDs of the private subnets (EC2 instances)."
   value       = module.vpc.private_subnet_ids
 }
 
+output "flow_log_group_name" {
+  description = "CloudWatch Log Group name for VPC Flow Logs."
+  value       = module.vpc.flow_log_group_name
+}
+
+# ── Security Group Outputs ────────────────────────────────────────────────────
+
+output "alb_security_group_id" {
+  description = "Security group ID attached to the Application Load Balancer."
+  value       = module.alb_sg.security_group_id
+}
+
 output "app_security_group_id" {
-  description = "Security group ID for the application layer"
+  description = "Security group ID for the application EC2 instances."
   value       = module.app_sg.security_group_id
 }
 
+# ── Load Balancer Outputs ─────────────────────────────────────────────────────
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer. Point your domain's CNAME to this value."
+  value       = module.alb.alb_dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer."
+  value       = module.alb.alb_arn
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group."
+  value       = module.alb.target_group_arn
+}
+
+# ── Storage Outputs ───────────────────────────────────────────────────────────
+
 output "app_storage_bucket" {
-  description = "Application S3 bucket name"
+  description = "Name of the application S3 bucket."
   value       = module.app_storage.bucket_id
 }
 
 output "app_storage_bucket_arn" {
-  description = "Application S3 bucket ARN"
+  description = "ARN of the application S3 bucket."
   value       = module.app_storage.bucket_arn
 }
 
-output "ec2_role_arn" {
-  description = "IAM role ARN for EC2 instances"
-  value       = module.ec2_role.role_arn
+output "access_logs_bucket" {
+  description = "Name of the S3 access logs bucket."
+  value       = module.access_logs_bucket.bucket_id
 }
 
+# ── Encryption Outputs ────────────────────────────────────────────────────────
+
+output "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used for S3 and EBS encryption."
+  value       = module.kms.key_arn
+}
+
+output "kms_key_alias" {
+  description = "Alias of the KMS key (e.g. alias/dev-app)."
+  value       = module.kms.alias_name
+}
+
+# ── Compute Outputs ───────────────────────────────────────────────────────────
+
 output "autoscaling_group_name" {
-  description = "Name of the application Auto Scaling Group"
+  description = "Name of the application Auto Scaling Group."
   value       = module.app_compute.autoscaling_group_name
 }
 
+output "launch_template_id" {
+  description = "ID of the EC2 launch template."
+  value       = module.app_compute.launch_template_id
+}
+
+# ── IAM Outputs ───────────────────────────────────────────────────────────────
+
+output "ec2_role_arn" {
+  description = "ARN of the IAM role attached to EC2 instances."
+  value       = module.ec2_role.role_arn
+}
+
+# ── Monitoring Outputs ────────────────────────────────────────────────────────
+
+output "alarm_sns_topic_arn" {
+  description = "ARN of the SNS topic that receives CloudWatch alarm notifications."
+  value       = module.monitoring.sns_topic_arn
+}
+
+# ── VPC Endpoint Outputs ──────────────────────────────────────────────────────
+
 output "vpc_endpoint_s3_id" {
-  description = "ID of the S3 VPC Gateway Endpoint"
+  description = "ID of the S3 VPC Gateway Endpoint."
   value       = module.vpc_endpoint_s3.vpc_endpoint_id
 }

--- a/environments/dev/providers.tf
+++ b/environments/dev/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.3.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/environments/dev/terraform.tfvars.example
+++ b/environments/dev/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy this file to terraform.tfvars and fill in the values.
+# terraform.tfvars is gitignored — never commit real values.
+
+# Your AWS account ID (12 digits, no hyphens)
+account_id = "123456789012"
+
+# AWS region — must match the region configured in your backend.tf
+region = "us-west-2"

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -1,4 +1,17 @@
 variable "region" {
-  description = "The AWS region"
+  description = "AWS region to deploy into"
+  type        = string
   default     = "us-west-2"
+}
+
+variable "account_id" {
+  description = "AWS account ID — used to ensure globally unique S3 bucket names"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instances (Amazon Linux 2023 in us-west-2)"
+  type        = string
+  # Amazon Linux 2023 — update this for your target region
+  default = "ami-0c55b159cbfafe1f0"
 }

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -2,16 +2,19 @@ variable "region" {
   description = "AWS region to deploy into"
   type        = string
   default     = "us-west-2"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]$", var.region))
+    error_message = "region must be a valid AWS region identifier, e.g. us-west-2."
+  }
 }
 
 variable "account_id" {
   description = "AWS account ID — used to ensure globally unique S3 bucket names"
   type        = string
-}
 
-variable "ami_id" {
-  description = "AMI ID for EC2 instances (Amazon Linux 2023 in us-west-2)"
-  type        = string
-  # Amazon Linux 2023 — update this for your target region
-  default = "ami-0c55b159cbfafe1f0"
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.account_id))
+    error_message = "account_id must be a 12-digit AWS account ID."
+  }
 }

--- a/environments/prod/.terraform.lock.hcl
+++ b/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -12,6 +12,22 @@ locals {
   }
 }
 
+# Resolve the latest Amazon Linux 2023 AMI for the target region automatically.
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
 # ── Networking ────────────────────────────────────────────────────────────────
 
 module "vpc" {
@@ -54,12 +70,15 @@ module "app_sg" {
   tags = local.tags
 }
 
+# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic.
 module "vpc_endpoint_s3" {
   source = "../../modules/networking/vpc-endpoint-module"
 
-  vpc_id        = module.vpc.vpc_id
-  service_name  = "com.amazonaws.${var.region}.s3"
-  endpoint_type = "Gateway"
+  vpc_id          = module.vpc.vpc_id
+  service_name    = "com.amazonaws.${var.region}.s3"
+  endpoint_type   = "Gateway"
+  route_table_ids = module.vpc.private_route_table_ids
+  tags            = local.tags
 }
 
 # ── IAM ──────────────────────────────────────────────────────────────────────
@@ -127,7 +146,7 @@ module "app_compute" {
   name        = "${local.environment}-app"
   environment = local.environment
 
-  ami_id               = var.ami_id
+  ami_id               = data.aws_ami.amazon_linux_2023.id
   instance_type        = "t3.medium"
   subnet_ids           = module.vpc.private_subnet_ids
   security_group_ids   = [module.app_sg.security_group_id]

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -1,10 +1,141 @@
+locals {
+  environment = "prod"
+
+  vpc_cidr             = "10.2.0.0/16"
+  azs                  = ["${var.region}a", "${var.region}b", "${var.region}c"]
+  public_subnet_cidrs  = ["10.2.1.0/24", "10.2.2.0/24", "10.2.3.0/24"]
+  private_subnet_cidrs = ["10.2.11.0/24", "10.2.12.0/24", "10.2.13.0/24"]
+
+  tags = {
+    Project = "demo"
+    Owner   = "platform-team"
+  }
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+module "vpc" {
+  source = "../../modules/networking/vpc-module"
+
+  environment          = local.environment
+  vpc_cidr             = local.vpc_cidr
+  azs                  = local.azs
+  public_subnet_cidrs  = local.public_subnet_cidrs
+  private_subnet_cidrs = local.private_subnet_cidrs
+  enable_nat_gateway   = true
+  single_nat_gateway   = false # One NAT GW per AZ for HA in production
+  tags                 = local.tags
+}
+
+module "app_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "${local.environment}-app-sg"
+  description = "Security group for ${local.environment} application servers"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_rules = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = [local.vpc_cidr]
+      description = "HTTP from within the VPC"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [local.vpc_cidr]
+      description = "HTTPS from within the VPC"
+    }
+  ]
+
+  tags = local.tags
+}
+
 module "vpc_endpoint_s3" {
-  source        = "github.com/theusc6/terraform-infrastructure//modules/networking/vpc-endpoint-module?ref=v0.1.0"
-  vpc_id        = "vpc-12345678"
-  service_name  = "com.amazonaws.region.s3"
+  source = "../../modules/networking/vpc-endpoint-module"
+
+  vpc_id        = module.vpc.vpc_id
+  service_name  = "com.amazonaws.${var.region}.s3"
   endpoint_type = "Gateway"
 }
 
-output "endpoint_id" {
-  value = module.vpc_endpoint_s3.vpc_endpoint_id
+# ── IAM ──────────────────────────────────────────────────────────────────────
+
+module "ec2_role" {
+  source = "../../modules/iam"
+
+  role_name   = "${local.environment}-ec2-role"
+  description = "IAM role for ${local.environment} EC2 instances"
+
+  trust_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+  ]
+
+  create_instance_profile = true
+  tags                    = local.tags
+}
+
+# ── Storage ───────────────────────────────────────────────────────────────────
+
+module "app_storage" {
+  source = "../../modules/storage"
+
+  bucket_name        = "${local.environment}-app-storage-${var.account_id}"
+  environment        = local.environment
+  versioning_enabled = true
+  force_destroy      = false
+
+  lifecycle_rules = [
+    {
+      id      = "transition-to-ia-then-glacier"
+      enabled = true
+      transition = [
+        {
+          days          = 30
+          storage_class = "STANDARD_IA"
+        },
+        {
+          days          = 90
+          storage_class = "GLACIER"
+        }
+      ]
+      noncurrent_version_expiration_days = 90
+    }
+  ]
+
+  tags = local.tags
+}
+
+# ── Compute ───────────────────────────────────────────────────────────────────
+
+module "app_compute" {
+  source = "../../modules/compute"
+
+  name        = "${local.environment}-app"
+  environment = local.environment
+
+  ami_id               = var.ami_id
+  instance_type        = "t3.medium"
+  subnet_ids           = module.vpc.private_subnet_ids
+  security_group_ids   = [module.app_sg.security_group_id]
+  iam_instance_profile = module.ec2_role.instance_profile_name
+
+  min_size         = 2
+  max_size         = 6
+  desired_capacity = 2
+
+  tags = local.tags
 }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -7,12 +7,12 @@ locals {
   private_subnet_cidrs = ["10.2.11.0/24", "10.2.12.0/24", "10.2.13.0/24"]
 
   tags = {
-    Project = "demo"
-    Owner   = "platform-team"
+    Project     = "demo"
+    Environment = local.environment
+    Owner       = "platform-team"
   }
 }
 
-# Resolve the latest Amazon Linux 2023 AMI for the target region automatically.
 data "aws_ami" "amazon_linux_2023" {
   most_recent = true
   owners      = ["amazon"]
@@ -28,7 +28,24 @@ data "aws_ami" "amazon_linux_2023" {
   }
 }
 
+# ── KMS ───────────────────────────────────────────────────────────────────────
+# Production uses a longer deletion window (30 days vs 7) so that accidental
+# key deletion can be caught and cancelled before data becomes unrecoverable.
+
+module "kms" {
+  source = "../../modules/kms"
+
+  alias_name              = "${local.environment}-app"
+  description             = "Customer-managed key for ${local.environment} S3 and EBS encryption"
+  environment             = local.environment
+  deletion_window_in_days = 30
+  tags                    = local.tags
+}
+
 # ── Networking ────────────────────────────────────────────────────────────────
+# Production runs one NAT gateway per AZ (single_nat_gateway = false).
+# This ensures that if an AZ fails, private instances in remaining AZs can
+# still reach the internet for software updates and AWS API calls.
 
 module "vpc" {
   source = "../../modules/networking/vpc-module"
@@ -39,8 +56,37 @@ module "vpc" {
   public_subnet_cidrs  = local.public_subnet_cidrs
   private_subnet_cidrs = local.private_subnet_cidrs
   enable_nat_gateway   = true
-  single_nat_gateway   = false # One NAT GW per AZ for HA in production
+  single_nat_gateway   = false  # One NAT GW per AZ for full AZ-level HA
+  enable_flow_logs     = true
+  flow_logs_retention_days = 90  # Retain 90 days of flow logs in production
   tags                 = local.tags
+}
+
+module "alb_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "${local.environment}-alb-sg"
+  description = "Security group for the ${local.environment} Application Load Balancer"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_rules = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTP from the internet (redirected to HTTPS by the listener)"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTPS from the internet"
+    },
+  ]
+
+  tags = local.tags
 }
 
 module "app_sg" {
@@ -50,27 +96,19 @@ module "app_sg" {
   description = "Security group for ${local.environment} application servers"
   vpc_id      = module.vpc.vpc_id
 
-  ingress_rules = [
+  ingress_sg_rules = [
     {
-      from_port   = 80
-      to_port     = 80
-      protocol    = "tcp"
-      cidr_blocks = [local.vpc_cidr]
-      description = "HTTP from within the VPC"
+      from_port                = 80
+      to_port                  = 80
+      protocol                 = "tcp"
+      source_security_group_id = module.alb_sg.security_group_id
+      description              = "HTTP from the ALB only — no direct internet access"
     },
-    {
-      from_port   = 443
-      to_port     = 443
-      protocol    = "tcp"
-      cidr_blocks = [local.vpc_cidr]
-      description = "HTTPS from within the VPC"
-    }
   ]
 
   tags = local.tags
 }
 
-# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic.
 module "vpc_endpoint_s3" {
   source = "../../modules/networking/vpc-endpoint-module"
 
@@ -79,6 +117,30 @@ module "vpc_endpoint_s3" {
   endpoint_type   = "Gateway"
   route_table_ids = module.vpc.private_route_table_ids
   tags            = local.tags
+}
+
+# ── Load Balancing ────────────────────────────────────────────────────────────
+# Production requires an ACM certificate for HTTPS. The HTTP listener automatically
+# redirects to HTTPS when certificate_arn is provided (see ALB module).
+# To provision a certificate, create an aws_acm_certificate resource or import
+# an existing certificate and pass its ARN via var.certificate_arn.
+
+module "alb" {
+  source = "../../modules/alb"
+
+  name        = "${local.environment}-app"
+  environment = local.environment
+  vpc_id      = module.vpc.vpc_id
+
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = [module.alb_sg.security_group_id]
+
+  certificate_arn            = var.certificate_arn
+  health_check_path          = "/health"
+  enable_deletion_protection = true  # Prevent accidental destroy of live load balancer
+  idle_timeout               = 120
+
+  tags = local.tags
 }
 
 # ── IAM ──────────────────────────────────────────────────────────────────────
@@ -109,13 +171,35 @@ module "ec2_role" {
 
 # ── Storage ───────────────────────────────────────────────────────────────────
 
+module "access_logs_bucket" {
+  source = "../../modules/storage"
+
+  bucket_name        = "${local.environment}-access-logs-${var.account_id}"
+  environment        = local.environment
+  versioning_enabled = false
+  kms_key_arn        = module.kms.key_arn
+  force_destroy      = false
+
+  lifecycle_rules = [
+    {
+      id              = "expire-logs"
+      enabled         = true
+      expiration_days = 90
+    }
+  ]
+
+  tags = local.tags
+}
+
 module "app_storage" {
   source = "../../modules/storage"
 
   bucket_name        = "${local.environment}-app-storage-${var.account_id}"
   environment        = local.environment
   versioning_enabled = true
-  force_destroy      = false
+  kms_key_arn        = module.kms.key_arn
+  logging_bucket_id  = module.access_logs_bucket.bucket_id
+  force_destroy      = false  # Safety: production data must be explicitly emptied first
 
   lifecycle_rules = [
     {
@@ -146,15 +230,37 @@ module "app_compute" {
   name        = "${local.environment}-app"
   environment = local.environment
 
-  ami_id               = data.aws_ami.amazon_linux_2023.id
-  instance_type        = "t3.medium"
-  subnet_ids           = module.vpc.private_subnet_ids
-  security_group_ids   = [module.app_sg.security_group_id]
-  iam_instance_profile = module.ec2_role.instance_profile_name
+  ami_id                    = data.aws_ami.amazon_linux_2023.id
+  instance_type             = "t3.medium"
+  kms_key_arn               = module.kms.key_arn
+  subnet_ids                = module.vpc.private_subnet_ids
+  security_group_ids        = [module.app_sg.security_group_id]
+  iam_instance_profile      = module.ec2_role.instance_profile_name
+  target_group_arns         = [module.alb.target_group_arn]
+  health_check_grace_period = 300  # Allow time for application startup
 
   min_size         = 2
   max_size         = 6
   desired_capacity = 2
+
+  tags = local.tags
+}
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  name                    = "${local.environment}-app"
+  environment             = local.environment
+  autoscaling_group_name  = module.app_compute.autoscaling_group_name
+  alb_arn_suffix          = module.alb.alb_arn_suffix
+  target_group_arn_suffix = module.alb.target_group_arn_suffix
+  alarm_email             = var.alarm_email
+
+  # Tighten thresholds in production — we have less tolerance for degradation
+  cpu_warning_threshold  = 60
+  cpu_critical_threshold = 80
 
   tags = local.tags
 }

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -1,1 +1,44 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
 
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = module.vpc.private_subnet_ids
+}
+
+output "app_security_group_id" {
+  description = "Security group ID for the application layer"
+  value       = module.app_sg.security_group_id
+}
+
+output "app_storage_bucket" {
+  description = "Application S3 bucket name"
+  value       = module.app_storage.bucket_id
+}
+
+output "app_storage_bucket_arn" {
+  description = "Application S3 bucket ARN"
+  value       = module.app_storage.bucket_arn
+}
+
+output "ec2_role_arn" {
+  description = "IAM role ARN for EC2 instances"
+  value       = module.ec2_role.role_arn
+}
+
+output "autoscaling_group_name" {
+  description = "Name of the application Auto Scaling Group"
+  value       = module.app_compute.autoscaling_group_name
+}
+
+output "vpc_endpoint_s3_id" {
+  description = "ID of the S3 VPC Gateway Endpoint"
+  value       = module.vpc_endpoint_s3.vpc_endpoint_id
+}

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -1,44 +1,112 @@
+# ── Network Outputs ───────────────────────────────────────────────────────────
+
 output "vpc_id" {
-  description = "The ID of the VPC"
+  description = "The ID of the VPC."
   value       = module.vpc.vpc_id
 }
 
 output "public_subnet_ids" {
-  description = "IDs of the public subnets"
+  description = "IDs of the public subnets (ALB, NAT gateways)."
   value       = module.vpc.public_subnet_ids
 }
 
 output "private_subnet_ids" {
-  description = "IDs of the private subnets"
+  description = "IDs of the private subnets (EC2 instances)."
   value       = module.vpc.private_subnet_ids
 }
 
+output "flow_log_group_name" {
+  description = "CloudWatch Log Group name for VPC Flow Logs."
+  value       = module.vpc.flow_log_group_name
+}
+
+# ── Security Group Outputs ────────────────────────────────────────────────────
+
+output "alb_security_group_id" {
+  description = "Security group ID attached to the Application Load Balancer."
+  value       = module.alb_sg.security_group_id
+}
+
 output "app_security_group_id" {
-  description = "Security group ID for the application layer"
+  description = "Security group ID for the application EC2 instances."
   value       = module.app_sg.security_group_id
 }
 
+# ── Load Balancer Outputs ─────────────────────────────────────────────────────
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer. Point your domain's CNAME to this value."
+  value       = module.alb.alb_dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer."
+  value       = module.alb.alb_arn
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group."
+  value       = module.alb.target_group_arn
+}
+
+# ── Storage Outputs ───────────────────────────────────────────────────────────
+
 output "app_storage_bucket" {
-  description = "Application S3 bucket name"
+  description = "Name of the application S3 bucket."
   value       = module.app_storage.bucket_id
 }
 
 output "app_storage_bucket_arn" {
-  description = "Application S3 bucket ARN"
+  description = "ARN of the application S3 bucket."
   value       = module.app_storage.bucket_arn
 }
 
-output "ec2_role_arn" {
-  description = "IAM role ARN for EC2 instances"
-  value       = module.ec2_role.role_arn
+output "access_logs_bucket" {
+  description = "Name of the S3 access logs bucket."
+  value       = module.access_logs_bucket.bucket_id
 }
 
+# ── Encryption Outputs ────────────────────────────────────────────────────────
+
+output "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used for S3 and EBS encryption."
+  value       = module.kms.key_arn
+}
+
+output "kms_key_alias" {
+  description = "Alias of the KMS key (e.g. alias/dev-app)."
+  value       = module.kms.alias_name
+}
+
+# ── Compute Outputs ───────────────────────────────────────────────────────────
+
 output "autoscaling_group_name" {
-  description = "Name of the application Auto Scaling Group"
+  description = "Name of the application Auto Scaling Group."
   value       = module.app_compute.autoscaling_group_name
 }
 
+output "launch_template_id" {
+  description = "ID of the EC2 launch template."
+  value       = module.app_compute.launch_template_id
+}
+
+# ── IAM Outputs ───────────────────────────────────────────────────────────────
+
+output "ec2_role_arn" {
+  description = "ARN of the IAM role attached to EC2 instances."
+  value       = module.ec2_role.role_arn
+}
+
+# ── Monitoring Outputs ────────────────────────────────────────────────────────
+
+output "alarm_sns_topic_arn" {
+  description = "ARN of the SNS topic that receives CloudWatch alarm notifications."
+  value       = module.monitoring.sns_topic_arn
+}
+
+# ── VPC Endpoint Outputs ──────────────────────────────────────────────────────
+
 output "vpc_endpoint_s3_id" {
-  description = "ID of the S3 VPC Gateway Endpoint"
+  description = "ID of the S3 VPC Gateway Endpoint."
   value       = module.vpc_endpoint_s3.vpc_endpoint_id
 }

--- a/environments/prod/providers.tf
+++ b/environments/prod/providers.tf
@@ -1,4 +1,14 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = "~> 5.0"
-  region  = var.region
+  region = var.region
 }

--- a/environments/prod/terraform.tfvars.example
+++ b/environments/prod/terraform.tfvars.example
@@ -4,5 +4,12 @@
 # Your AWS account ID (12 digits, no hyphens)
 account_id = "123456789012"
 
-# AWS region — must match the region configured in your backend.tf
+# AWS region — must match the region configured in backend.tf
 region = "us-west-2"
+
+# ACM certificate ARN for HTTPS (required for production).
+# Provision via the AWS Console, CLI, or an aws_acm_certificate resource.
+certificate_arn = "arn:aws:acm:us-west-2:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# Email for CloudWatch alarm notifications. A confirmation email will be sent.
+alarm_email = "ops-team@example.com"

--- a/environments/prod/terraform.tfvars.example
+++ b/environments/prod/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy this file to terraform.tfvars and fill in the values.
+# terraform.tfvars is gitignored — never commit real values.
+
+# Your AWS account ID (12 digits, no hyphens)
+account_id = "123456789012"
+
+# AWS region — must match the region configured in your backend.tf
+region = "us-west-2"

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -22,7 +22,11 @@ variable "account_id" {
 variable "certificate_arn" {
   description = "ACM certificate ARN for HTTPS. Required for production — the ALB will redirect HTTP to HTTPS. Provision via aws_acm_certificate or import an existing cert."
   type        = string
-  default     = null
+
+  validation {
+    condition     = can(regex("^arn:aws:acm:[a-z0-9-]+:[0-9]{12}:certificate/[a-f0-9-]+$", var.certificate_arn))
+    error_message = "certificate_arn must be a valid ACM certificate ARN (arn:aws:acm:<region>:<account>:certificate/<id>). HTTPS is required in production."
+  }
 }
 
 variable "alarm_email" {

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -1,4 +1,16 @@
 variable "region" {
-  description = "The AWS region"
+  description = "AWS region to deploy into"
+  type        = string
   default     = "us-west-2"
+}
+
+variable "account_id" {
+  description = "AWS account ID — used to ensure globally unique S3 bucket names"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instances (Amazon Linux 2023 in us-west-2)"
+  type        = string
+  default     = "ami-0c55b159cbfafe1f0"
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -1,5 +1,5 @@
 variable "region" {
-  description = "AWS region to deploy into"
+  description = "AWS region to deploy into."
   type        = string
   default     = "us-west-2"
 
@@ -10,11 +10,23 @@ variable "region" {
 }
 
 variable "account_id" {
-  description = "AWS account ID — used to ensure globally unique S3 bucket names"
+  description = "AWS account ID — used to ensure globally unique S3 bucket names."
   type        = string
 
   validation {
     condition     = can(regex("^[0-9]{12}$", var.account_id))
     error_message = "account_id must be a 12-digit AWS account ID."
   }
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS. Required for production — the ALB will redirect HTTP to HTTPS. Provision via aws_acm_certificate or import an existing cert."
+  type        = string
+  default     = null
+}
+
+variable "alarm_email" {
+  description = "Email address to receive CloudWatch alarm notifications. A confirmation email will be sent to this address."
+  type        = string
+  default     = null
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -2,15 +2,19 @@ variable "region" {
   description = "AWS region to deploy into"
   type        = string
   default     = "us-west-2"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]$", var.region))
+    error_message = "region must be a valid AWS region identifier, e.g. us-west-2."
+  }
 }
 
 variable "account_id" {
   description = "AWS account ID — used to ensure globally unique S3 bucket names"
   type        = string
-}
 
-variable "ami_id" {
-  description = "AMI ID for EC2 instances (Amazon Linux 2023 in us-west-2)"
-  type        = string
-  default     = "ami-0c55b159cbfafe1f0"
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.account_id))
+    error_message = "account_id must be a 12-digit AWS account ID."
+  }
 }

--- a/environments/staging/.terraform.lock.hcl
+++ b/environments/staging/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -7,12 +7,12 @@ locals {
   private_subnet_cidrs = ["10.1.11.0/24", "10.1.12.0/24"]
 
   tags = {
-    Project = "demo"
-    Owner   = "platform-team"
+    Project     = "demo"
+    Environment = local.environment
+    Owner       = "platform-team"
   }
 }
 
-# Resolve the latest Amazon Linux 2023 AMI for the target region automatically.
 data "aws_ami" "amazon_linux_2023" {
   most_recent = true
   owners      = ["amazon"]
@@ -28,6 +28,17 @@ data "aws_ami" "amazon_linux_2023" {
   }
 }
 
+# ── KMS ───────────────────────────────────────────────────────────────────────
+
+module "kms" {
+  source = "../../modules/kms"
+
+  alias_name  = "${local.environment}-app"
+  description = "Customer-managed key for ${local.environment} S3 and EBS encryption"
+  environment = local.environment
+  tags        = local.tags
+}
+
 # ── Networking ────────────────────────────────────────────────────────────────
 
 module "vpc" {
@@ -39,8 +50,36 @@ module "vpc" {
   public_subnet_cidrs  = local.public_subnet_cidrs
   private_subnet_cidrs = local.private_subnet_cidrs
   enable_nat_gateway   = true
-  single_nat_gateway   = true # Single NAT GW is acceptable for staging
+  single_nat_gateway   = true  # Single NAT is acceptable for staging (non-HA)
+  enable_flow_logs     = true
   tags                 = local.tags
+}
+
+module "alb_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "${local.environment}-alb-sg"
+  description = "Security group for the ${local.environment} Application Load Balancer"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_rules = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTP from the internet"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTPS from the internet"
+    },
+  ]
+
+  tags = local.tags
 }
 
 module "app_sg" {
@@ -50,27 +89,19 @@ module "app_sg" {
   description = "Security group for ${local.environment} application servers"
   vpc_id      = module.vpc.vpc_id
 
-  ingress_rules = [
+  ingress_sg_rules = [
     {
-      from_port   = 80
-      to_port     = 80
-      protocol    = "tcp"
-      cidr_blocks = [local.vpc_cidr]
-      description = "HTTP from within the VPC"
+      from_port                = 80
+      to_port                  = 80
+      protocol                 = "tcp"
+      source_security_group_id = module.alb_sg.security_group_id
+      description              = "HTTP from the ALB only"
     },
-    {
-      from_port   = 443
-      to_port     = 443
-      protocol    = "tcp"
-      cidr_blocks = [local.vpc_cidr]
-      description = "HTTPS from within the VPC"
-    }
   ]
 
   tags = local.tags
 }
 
-# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic.
 module "vpc_endpoint_s3" {
   source = "../../modules/networking/vpc-endpoint-module"
 
@@ -79,6 +110,28 @@ module "vpc_endpoint_s3" {
   endpoint_type   = "Gateway"
   route_table_ids = module.vpc.private_route_table_ids
   tags            = local.tags
+}
+
+# ── Load Balancing ────────────────────────────────────────────────────────────
+
+module "alb" {
+  source = "../../modules/alb"
+
+  name        = "${local.environment}-app"
+  environment = local.environment
+  vpc_id      = module.vpc.vpc_id
+
+  subnet_ids         = module.vpc.public_subnet_ids
+  security_group_ids = [module.alb_sg.security_group_id]
+
+  # Provide an ACM certificate ARN via var.certificate_arn to enable HTTPS.
+  # When set, HTTP traffic is automatically redirected to HTTPS (301).
+  certificate_arn = var.certificate_arn
+
+  health_check_path          = "/health"
+  enable_deletion_protection = false
+
+  tags = local.tags
 }
 
 # ── IAM ──────────────────────────────────────────────────────────────────────
@@ -109,12 +162,33 @@ module "ec2_role" {
 
 # ── Storage ───────────────────────────────────────────────────────────────────
 
+module "access_logs_bucket" {
+  source = "../../modules/storage"
+
+  bucket_name        = "${local.environment}-access-logs-${var.account_id}"
+  environment        = local.environment
+  versioning_enabled = false
+  kms_key_arn        = module.kms.key_arn
+
+  lifecycle_rules = [
+    {
+      id              = "expire-logs"
+      enabled         = true
+      expiration_days = 30
+    }
+  ]
+
+  tags = local.tags
+}
+
 module "app_storage" {
   source = "../../modules/storage"
 
   bucket_name        = "${local.environment}-app-storage-${var.account_id}"
   environment        = local.environment
   versioning_enabled = true
+  kms_key_arn        = module.kms.key_arn
+  logging_bucket_id  = module.access_logs_bucket.bucket_id
 
   lifecycle_rules = [
     {
@@ -141,15 +215,33 @@ module "app_compute" {
   name        = "${local.environment}-app"
   environment = local.environment
 
-  ami_id               = data.aws_ami.amazon_linux_2023.id
-  instance_type        = "t3.small"
-  subnet_ids           = module.vpc.private_subnet_ids
-  security_group_ids   = [module.app_sg.security_group_id]
-  iam_instance_profile = module.ec2_role.instance_profile_name
+  ami_id                    = data.aws_ami.amazon_linux_2023.id
+  instance_type             = "t3.small"
+  kms_key_arn               = module.kms.key_arn
+  subnet_ids                = module.vpc.private_subnet_ids
+  security_group_ids        = [module.app_sg.security_group_id]
+  iam_instance_profile      = module.ec2_role.instance_profile_name
+  target_group_arns         = [module.alb.target_group_arn]
+  health_check_grace_period = 180
 
   min_size         = 1
   max_size         = 4
   desired_capacity = 2
+
+  tags = local.tags
+}
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  name                    = "${local.environment}-app"
+  environment             = local.environment
+  autoscaling_group_name  = module.app_compute.autoscaling_group_name
+  alb_arn_suffix          = module.alb.alb_arn_suffix
+  target_group_arn_suffix = module.alb.target_group_arn_suffix
+  alarm_email             = var.alarm_email
 
   tags = local.tags
 }

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -1,1 +1,136 @@
+locals {
+  environment = "staging"
 
+  vpc_cidr             = "10.1.0.0/16"
+  azs                  = ["${var.region}a", "${var.region}b"]
+  public_subnet_cidrs  = ["10.1.1.0/24", "10.1.2.0/24"]
+  private_subnet_cidrs = ["10.1.11.0/24", "10.1.12.0/24"]
+
+  tags = {
+    Project = "demo"
+    Owner   = "platform-team"
+  }
+}
+
+# ── Networking ────────────────────────────────────────────────────────────────
+
+module "vpc" {
+  source = "../../modules/networking/vpc-module"
+
+  environment          = local.environment
+  vpc_cidr             = local.vpc_cidr
+  azs                  = local.azs
+  public_subnet_cidrs  = local.public_subnet_cidrs
+  private_subnet_cidrs = local.private_subnet_cidrs
+  enable_nat_gateway   = true
+  single_nat_gateway   = true # Single NAT GW is acceptable for staging
+  tags                 = local.tags
+}
+
+module "app_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "${local.environment}-app-sg"
+  description = "Security group for ${local.environment} application servers"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_rules = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = [local.vpc_cidr]
+      description = "HTTP from within the VPC"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = [local.vpc_cidr]
+      description = "HTTPS from within the VPC"
+    }
+  ]
+
+  tags = local.tags
+}
+
+module "vpc_endpoint_s3" {
+  source = "../../modules/networking/vpc-endpoint-module"
+
+  vpc_id        = module.vpc.vpc_id
+  service_name  = "com.amazonaws.${var.region}.s3"
+  endpoint_type = "Gateway"
+}
+
+# ── IAM ──────────────────────────────────────────────────────────────────────
+
+module "ec2_role" {
+  source = "../../modules/iam"
+
+  role_name   = "${local.environment}-ec2-role"
+  description = "IAM role for ${local.environment} EC2 instances"
+
+  trust_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+  ]
+
+  create_instance_profile = true
+  tags                    = local.tags
+}
+
+# ── Storage ───────────────────────────────────────────────────────────────────
+
+module "app_storage" {
+  source = "../../modules/storage"
+
+  bucket_name        = "${local.environment}-app-storage-${var.account_id}"
+  environment        = local.environment
+  versioning_enabled = true
+
+  lifecycle_rules = [
+    {
+      id      = "transition-to-ia"
+      enabled = true
+      transition = [
+        {
+          days          = 30
+          storage_class = "STANDARD_IA"
+        }
+      ]
+      noncurrent_version_expiration_days = 60
+    }
+  ]
+
+  tags = local.tags
+}
+
+# ── Compute ───────────────────────────────────────────────────────────────────
+
+module "app_compute" {
+  source = "../../modules/compute"
+
+  name        = "${local.environment}-app"
+  environment = local.environment
+
+  ami_id               = var.ami_id
+  instance_type        = "t3.small"
+  subnet_ids           = module.vpc.private_subnet_ids
+  security_group_ids   = [module.app_sg.security_group_id]
+  iam_instance_profile = module.ec2_role.instance_profile_name
+
+  min_size         = 1
+  max_size         = 4
+  desired_capacity = 2
+
+  tags = local.tags
+}

--- a/environments/staging/main.tf
+++ b/environments/staging/main.tf
@@ -12,6 +12,22 @@ locals {
   }
 }
 
+# Resolve the latest Amazon Linux 2023 AMI for the target region automatically.
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
 # ── Networking ────────────────────────────────────────────────────────────────
 
 module "vpc" {
@@ -54,12 +70,15 @@ module "app_sg" {
   tags = local.tags
 }
 
+# VPC Endpoint for S3 — avoids NAT gateway charges for S3 traffic.
 module "vpc_endpoint_s3" {
   source = "../../modules/networking/vpc-endpoint-module"
 
-  vpc_id        = module.vpc.vpc_id
-  service_name  = "com.amazonaws.${var.region}.s3"
-  endpoint_type = "Gateway"
+  vpc_id          = module.vpc.vpc_id
+  service_name    = "com.amazonaws.${var.region}.s3"
+  endpoint_type   = "Gateway"
+  route_table_ids = module.vpc.private_route_table_ids
+  tags            = local.tags
 }
 
 # ── IAM ──────────────────────────────────────────────────────────────────────
@@ -122,7 +141,7 @@ module "app_compute" {
   name        = "${local.environment}-app"
   environment = local.environment
 
-  ami_id               = var.ami_id
+  ami_id               = data.aws_ami.amazon_linux_2023.id
   instance_type        = "t3.small"
   subnet_ids           = module.vpc.private_subnet_ids
   security_group_ids   = [module.app_sg.security_group_id]

--- a/environments/staging/outputs.tf
+++ b/environments/staging/outputs.tf
@@ -1,1 +1,44 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = module.vpc.vpc_id
+}
 
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = module.vpc.private_subnet_ids
+}
+
+output "app_security_group_id" {
+  description = "Security group ID for the application layer"
+  value       = module.app_sg.security_group_id
+}
+
+output "app_storage_bucket" {
+  description = "Application S3 bucket name"
+  value       = module.app_storage.bucket_id
+}
+
+output "app_storage_bucket_arn" {
+  description = "Application S3 bucket ARN"
+  value       = module.app_storage.bucket_arn
+}
+
+output "ec2_role_arn" {
+  description = "IAM role ARN for EC2 instances"
+  value       = module.ec2_role.role_arn
+}
+
+output "autoscaling_group_name" {
+  description = "Name of the application Auto Scaling Group"
+  value       = module.app_compute.autoscaling_group_name
+}
+
+output "vpc_endpoint_s3_id" {
+  description = "ID of the S3 VPC Gateway Endpoint"
+  value       = module.vpc_endpoint_s3.vpc_endpoint_id
+}

--- a/environments/staging/outputs.tf
+++ b/environments/staging/outputs.tf
@@ -1,44 +1,112 @@
+# ── Network Outputs ───────────────────────────────────────────────────────────
+
 output "vpc_id" {
-  description = "The ID of the VPC"
+  description = "The ID of the VPC."
   value       = module.vpc.vpc_id
 }
 
 output "public_subnet_ids" {
-  description = "IDs of the public subnets"
+  description = "IDs of the public subnets (ALB, NAT gateways)."
   value       = module.vpc.public_subnet_ids
 }
 
 output "private_subnet_ids" {
-  description = "IDs of the private subnets"
+  description = "IDs of the private subnets (EC2 instances)."
   value       = module.vpc.private_subnet_ids
 }
 
+output "flow_log_group_name" {
+  description = "CloudWatch Log Group name for VPC Flow Logs."
+  value       = module.vpc.flow_log_group_name
+}
+
+# ── Security Group Outputs ────────────────────────────────────────────────────
+
+output "alb_security_group_id" {
+  description = "Security group ID attached to the Application Load Balancer."
+  value       = module.alb_sg.security_group_id
+}
+
 output "app_security_group_id" {
-  description = "Security group ID for the application layer"
+  description = "Security group ID for the application EC2 instances."
   value       = module.app_sg.security_group_id
 }
 
+# ── Load Balancer Outputs ─────────────────────────────────────────────────────
+
+output "alb_dns_name" {
+  description = "DNS name of the Application Load Balancer. Point your domain's CNAME to this value."
+  value       = module.alb.alb_dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the Application Load Balancer."
+  value       = module.alb.alb_arn
+}
+
+output "target_group_arn" {
+  description = "ARN of the ALB target group."
+  value       = module.alb.target_group_arn
+}
+
+# ── Storage Outputs ───────────────────────────────────────────────────────────
+
 output "app_storage_bucket" {
-  description = "Application S3 bucket name"
+  description = "Name of the application S3 bucket."
   value       = module.app_storage.bucket_id
 }
 
 output "app_storage_bucket_arn" {
-  description = "Application S3 bucket ARN"
+  description = "ARN of the application S3 bucket."
   value       = module.app_storage.bucket_arn
 }
 
-output "ec2_role_arn" {
-  description = "IAM role ARN for EC2 instances"
-  value       = module.ec2_role.role_arn
+output "access_logs_bucket" {
+  description = "Name of the S3 access logs bucket."
+  value       = module.access_logs_bucket.bucket_id
 }
 
+# ── Encryption Outputs ────────────────────────────────────────────────────────
+
+output "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used for S3 and EBS encryption."
+  value       = module.kms.key_arn
+}
+
+output "kms_key_alias" {
+  description = "Alias of the KMS key (e.g. alias/dev-app)."
+  value       = module.kms.alias_name
+}
+
+# ── Compute Outputs ───────────────────────────────────────────────────────────
+
 output "autoscaling_group_name" {
-  description = "Name of the application Auto Scaling Group"
+  description = "Name of the application Auto Scaling Group."
   value       = module.app_compute.autoscaling_group_name
 }
 
+output "launch_template_id" {
+  description = "ID of the EC2 launch template."
+  value       = module.app_compute.launch_template_id
+}
+
+# ── IAM Outputs ───────────────────────────────────────────────────────────────
+
+output "ec2_role_arn" {
+  description = "ARN of the IAM role attached to EC2 instances."
+  value       = module.ec2_role.role_arn
+}
+
+# ── Monitoring Outputs ────────────────────────────────────────────────────────
+
+output "alarm_sns_topic_arn" {
+  description = "ARN of the SNS topic that receives CloudWatch alarm notifications."
+  value       = module.monitoring.sns_topic_arn
+}
+
+# ── VPC Endpoint Outputs ──────────────────────────────────────────────────────
+
 output "vpc_endpoint_s3_id" {
-  description = "ID of the S3 VPC Gateway Endpoint"
+  description = "ID of the S3 VPC Gateway Endpoint."
   value       = module.vpc_endpoint_s3.vpc_endpoint_id
 }

--- a/environments/staging/providers.tf
+++ b/environments/staging/providers.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.3.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/environments/staging/providers.tf
+++ b/environments/staging/providers.tf
@@ -1,4 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
 provider "aws" {
-  version = "~> 5.0"
-  region  = var.region
+  region = var.region
 }

--- a/environments/staging/terraform.tfvars.example
+++ b/environments/staging/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy this file to terraform.tfvars and fill in the values.
+# terraform.tfvars is gitignored — never commit real values.
+
+# Your AWS account ID (12 digits, no hyphens)
+account_id = "123456789012"
+
+# AWS region — must match the region configured in your backend.tf
+region = "us-west-2"

--- a/environments/staging/terraform.tfvars.example
+++ b/environments/staging/terraform.tfvars.example
@@ -4,5 +4,11 @@
 # Your AWS account ID (12 digits, no hyphens)
 account_id = "123456789012"
 
-# AWS region — must match the region configured in your backend.tf
+# AWS region — must match the region configured in backend.tf
 region = "us-west-2"
+
+# Optional: ACM certificate ARN for HTTPS. Leave commented out to use HTTP only.
+# certificate_arn = "arn:aws:acm:us-west-2:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# Optional: Email for CloudWatch alarm notifications
+# alarm_email = "ops-team@example.com"

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -1,5 +1,5 @@
 variable "region" {
-  description = "AWS region to deploy into"
+  description = "AWS region to deploy into."
   type        = string
   default     = "us-west-2"
 
@@ -10,11 +10,23 @@ variable "region" {
 }
 
 variable "account_id" {
-  description = "AWS account ID — used to ensure globally unique S3 bucket names"
+  description = "AWS account ID — used to ensure globally unique S3 bucket names."
   type        = string
 
   validation {
     condition     = can(regex("^[0-9]{12}$", var.account_id))
     error_message = "account_id must be a 12-digit AWS account ID."
   }
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS. When provided, the ALB HTTP listener redirects to HTTPS. Leave null to serve HTTP only."
+  type        = string
+  default     = null
+}
+
+variable "alarm_email" {
+  description = "Email address to receive CloudWatch alarm notifications. Leave null to disable email subscriptions."
+  type        = string
+  default     = null
 }

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -1,4 +1,16 @@
 variable "region" {
-  description = "The AWS region."
+  description = "AWS region to deploy into"
+  type        = string
   default     = "us-west-2"
+}
+
+variable "account_id" {
+  description = "AWS account ID — used to ensure globally unique S3 bucket names"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instances (Amazon Linux 2023 in us-west-2)"
+  type        = string
+  default     = "ami-0c55b159cbfafe1f0"
 }

--- a/environments/staging/variables.tf
+++ b/environments/staging/variables.tf
@@ -2,15 +2,19 @@ variable "region" {
   description = "AWS region to deploy into"
   type        = string
   default     = "us-west-2"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-[0-9]$", var.region))
+    error_message = "region must be a valid AWS region identifier, e.g. us-west-2."
+  }
 }
 
 variable "account_id" {
   description = "AWS account ID — used to ensure globally unique S3 bucket names"
   type        = string
-}
 
-variable "ami_id" {
-  description = "AMI ID for EC2 instances (Amazon Linux 2023 in us-west-2)"
-  type        = string
-  default     = "ami-0c55b159cbfafe1f0"
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.account_id))
+    error_message = "account_id must be a 12-digit AWS account ID."
+  }
 }

--- a/modules/alb/.terraform.lock.hcl
+++ b/modules/alb/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/alb/README.md
+++ b/modules/alb/README.md
@@ -1,0 +1,140 @@
+# modules/alb
+
+Creates an **Application Load Balancer** with a target group and HTTP/HTTPS listeners. Designed to sit in front of an Auto Scaling Group created by the `compute` module.
+
+Key behaviours:
+- When a TLS certificate ARN is provided, the HTTP listener issues a permanent (301) redirect to HTTPS and a separate HTTPS listener is created.
+- When no certificate is provided (e.g. dev), HTTP traffic is forwarded directly to the target group — no redirect loop.
+- Target group membership is managed entirely by the Auto Scaling Group (pass the target group ARN to the compute module's `target_group_arns`).
+- The `create_before_destroy` lifecycle rule on the target group prevents a brief window of zero healthy targets during replacement.
+
+---
+
+## Usage
+
+### HTTP only (dev)
+
+```hcl
+module "alb" {
+  source = "../../modules/alb"
+
+  name        = "my-app-dev"
+  environment = "dev"
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.public_subnet_ids
+  security_group_ids = [module.alb_sg.security_group_id]
+
+  health_check_path = "/health"
+  target_port       = 8080
+}
+```
+
+### HTTPS with redirect (staging / prod)
+
+```hcl
+module "alb" {
+  source = "../../modules/alb"
+
+  name        = "my-app-prod"
+  environment = "prod"
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.public_subnet_ids
+  security_group_ids = [module.alb_sg.security_group_id]
+
+  certificate_arn            = "arn:aws:acm:us-west-2:123456789012:certificate/abc..."
+  ssl_policy                 = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  enable_deletion_protection = true
+
+  health_check_path    = "/health"
+  target_port          = 8080
+  deregistration_delay = 60
+}
+```
+
+### Wire up the compute module
+
+```hcl
+module "compute" {
+  source = "../../modules/compute"
+
+  # ... other variables ...
+
+  target_group_arns = [module.alb.target_group_arn]
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `name` | Name prefix for all ALB resources (ALB, target group, listeners). | `string` | — | yes |
+| `environment` | Environment name (e.g. dev, staging, prod). | `string` | — | yes |
+| `vpc_id` | VPC ID in which the ALB and target group will be created. | `string` | — | yes |
+| `subnet_ids` | List of public subnet IDs across multiple AZs. At least two subnets in different AZs are required. | `list(string)` | — | yes |
+| `security_group_ids` | List of security group IDs to attach to the ALB. The SG should allow inbound 80 and 443 from the internet. | `list(string)` | — | yes |
+| `internal` | Set to `true` for an internal (private) ALB. `false` creates an internet-facing ALB. | `bool` | `false` | no |
+| `enable_deletion_protection` | Prevent accidental deletion of the ALB. Always enable this in production. | `bool` | `false` | no |
+| `idle_timeout` | Time in seconds the ALB waits for a client to send a request before closing the connection. | `number` | `60` | no |
+| `target_port` | Port on which EC2 instances receive traffic from the ALB. | `number` | `80` | no |
+| `health_check_path` | HTTP path used to assess target health. Must return 2xx or 3xx. | `string` | `"/health"` | no |
+| `deregistration_delay` | Seconds the ALB waits after a target begins deregistering before completing deregistration. Allows in-flight requests to finish. | `number` | `30` | no |
+| `certificate_arn` | ACM certificate ARN for HTTPS. When provided, HTTP redirects to HTTPS and an HTTPS listener is created. Leave `null` for HTTP-only. | `string` | `null` | no |
+| `ssl_policy` | SSL/TLS negotiation policy for the HTTPS listener. | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
+| `tags` | Additional tags applied to all ALB resources. | `map(string)` | `{}` | no |
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `alb_id` | The ID of the Application Load Balancer. |
+| `alb_arn` | The ARN of the Application Load Balancer. |
+| `alb_arn_suffix` | The ARN suffix of the ALB. Used as a CloudWatch metric dimension. |
+| `alb_dns_name` | The DNS name of the ALB. Point your domain's CNAME or alias record here. |
+| `alb_zone_id` | The canonical hosted zone ID of the ALB. Required for Route 53 alias records. |
+| `target_group_arn` | The ARN of the ALB target group. Pass to the compute module's `target_group_arns`. |
+| `target_group_arn_suffix` | The ARN suffix of the target group. Used as a CloudWatch metric dimension. |
+| `http_listener_arn` | The ARN of the HTTP (port 80) listener. |
+| `https_listener_arn` | The ARN of the HTTPS (port 443) listener. Empty string if no certificate was provided. |
+
+---
+
+## Notes
+
+### Security group requirements
+
+The ALB security group must allow:
+- Inbound TCP 80 from `0.0.0.0/0` (redirected to 443)
+- Inbound TCP 443 from `0.0.0.0/0` (when HTTPS is enabled)
+- Outbound TCP `target_port` to the EC2 instance security group
+
+The EC2 instance security group must allow:
+- Inbound TCP `target_port` from the ALB security group only (not from the internet)
+
+### SSL policy selection
+
+The default `ELBSecurityPolicy-TLS13-1-2-2021-06` enforces TLS 1.2+ and prefers TLS 1.3. This drops support for older clients (IE11, Android < 5.0). If broader compatibility is required, use `ELBSecurityPolicy-TLS-1-2-Ext-2018-06`.
+
+### Deregistration delay
+
+The default `30` seconds is intentionally low for dev/staging. In production, set this to at least `60` (or match your application's longest request duration) to ensure graceful draining.
+
+### Cost implications
+
+An Application Load Balancer incurs:
+- An hourly charge per ALB (~$0.008/hour in us-east-1)
+- LCU (Load Balancer Capacity Unit) charges based on traffic volume
+
+For dev environments with minimal traffic, costs are negligible. For production, monitor LCU usage in CloudWatch.

--- a/modules/alb/alb_unit.tftest.hcl
+++ b/modules/alb/alb_unit.tftest.hcl
@@ -1,0 +1,148 @@
+# Unit tests for modules/alb
+# Run with: terraform -chdir=modules/alb test
+
+mock_provider "aws" {}
+
+# ── Test: HTTP-only (no certificate) ─────────────────────────────────────────
+
+run "http_only_when_no_certificate" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "dev"
+    vpc_id             = "vpc-12345678"
+    subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids = ["sg-12345678"]
+  }
+
+  assert {
+    condition     = length(aws_lb_listener.https) == 0
+    error_message = "No HTTPS listener should be created when certificate_arn is null."
+  }
+}
+
+# ── Test: HTTPS listener created when certificate is provided ─────────────────
+
+run "https_listener_created_with_certificate" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "prod"
+    vpc_id             = "vpc-12345678"
+    subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids = ["sg-12345678"]
+    certificate_arn    = "arn:aws:acm:us-west-2:123456789012:certificate/fake-cert-id"
+  }
+
+  assert {
+    condition     = length(aws_lb_listener.https) == 1
+    error_message = "HTTPS listener must be created when certificate_arn is provided."
+  }
+
+  assert {
+    condition     = aws_lb_listener.https[0].port == 443
+    error_message = "HTTPS listener must be on port 443."
+  }
+
+  assert {
+    condition     = aws_lb_listener.https[0].protocol == "HTTPS"
+    error_message = "HTTPS listener protocol must be HTTPS."
+  }
+}
+
+# ── Test: SSL policy ──────────────────────────────────────────────────────────
+
+run "default_ssl_policy_is_tls13" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "prod"
+    vpc_id             = "vpc-12345678"
+    subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids = ["sg-12345678"]
+    certificate_arn    = "arn:aws:acm:us-west-2:123456789012:certificate/fake-cert-id"
+  }
+
+  assert {
+    condition     = aws_lb_listener.https[0].ssl_policy == "ELBSecurityPolicy-TLS13-1-2-2021-06"
+    error_message = "Default SSL policy must enforce TLS 1.2+ with TLS 1.3 preference."
+  }
+}
+
+# ── Test: deletion protection default ────────────────────────────────────────
+
+run "deletion_protection_off_by_default" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "dev"
+    vpc_id             = "vpc-12345678"
+    subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids = ["sg-12345678"]
+  }
+
+  assert {
+    condition     = aws_lb.this.enable_deletion_protection == false
+    error_message = "Deletion protection should be off by default (callers enable it for prod)."
+  }
+}
+
+run "deletion_protection_can_be_enabled" {
+  command = plan
+
+  variables {
+    name                       = "test-app"
+    environment                = "prod"
+    vpc_id                     = "vpc-12345678"
+    subnet_ids                 = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids         = ["sg-12345678"]
+    enable_deletion_protection = true
+  }
+
+  assert {
+    condition     = aws_lb.this.enable_deletion_protection == true
+    error_message = "Deletion protection should be enabled when set to true."
+  }
+}
+
+# ── Test: target group is internet-facing (instance type) ────────────────────
+
+run "target_group_is_instance_type" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "dev"
+    vpc_id             = "vpc-12345678"
+    subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids = ["sg-12345678"]
+  }
+
+  assert {
+    condition     = aws_lb_target_group.this.target_type == "instance"
+    error_message = "Target group must use instance target type for ASG integration."
+  }
+}
+
+# ── Test: internal flag ───────────────────────────────────────────────────────
+
+run "alb_is_internet_facing_by_default" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "dev"
+    vpc_id             = "vpc-12345678"
+    subnet_ids         = ["subnet-aaa", "subnet-bbb"]
+    security_group_ids = ["sg-12345678"]
+  }
+
+  assert {
+    condition     = aws_lb.this.internal == false
+    error_message = "ALB should be internet-facing by default."
+  }
+}

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -1,0 +1,120 @@
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+
+# ── Target Group ──────────────────────────────────────────────────────────────
+# The target group is the destination for traffic routed by the ALB listener.
+# We register EC2 instances via the ASG's target_group_arns — not here —
+# so the membership is managed entirely by the Auto Scaling Group.
+
+resource "aws_lb_target_group" "this" {
+  name        = "${var.name}-tg"
+  port        = var.target_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "instance"
+
+  # Deregistration delay: time (seconds) the ALB waits for in-flight requests
+  # to complete before removing a deregistering instance from service.
+  deregistration_delay = var.deregistration_delay
+
+  health_check {
+    enabled             = true
+    path                = var.health_check_path
+    protocol            = "HTTP"
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200-399"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}-tg"
+  })
+
+  # Replace the old target group before destroying the new one when settings
+  # change — prevents the 400ms window during which no healthy targets exist.
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ── Application Load Balancer ─────────────────────────────────────────────────
+
+resource "aws_lb" "this" {
+  name               = "${var.name}-alb"
+  internal           = var.internal
+  load_balancer_type = "application"
+  security_groups    = var.security_group_ids
+  subnets            = var.subnet_ids
+
+  # Prevent accidental deletion of a load balancer that is serving live traffic.
+  enable_deletion_protection = var.enable_deletion_protection
+
+  idle_timeout = var.idle_timeout
+
+  # Forward the originating client IP to backend instances via the
+  # X-Forwarded-For header, which is added by ALBs automatically.
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}-alb"
+  })
+}
+
+# ── HTTP Listener ─────────────────────────────────────────────────────────────
+# When a certificate ARN is provided, redirect all HTTP traffic to HTTPS.
+# When no certificate is configured (e.g. dev), forward directly to the target group.
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  dynamic "default_action" {
+    for_each = var.certificate_arn != null ? ["redirect"] : []
+    content {
+      type = "redirect"
+      redirect {
+        port        = "443"
+        protocol    = "HTTPS"
+        status_code = "HTTP_301"
+      }
+    }
+  }
+
+  dynamic "default_action" {
+    for_each = var.certificate_arn == null ? ["forward"] : []
+    content {
+      type             = "forward"
+      target_group_arn = aws_lb_target_group.this.arn
+    }
+  }
+}
+
+# ── HTTPS Listener ────────────────────────────────────────────────────────────
+# Created only when an ACM certificate ARN is provided.
+# In production, provision a certificate via aws_acm_certificate (or import an
+# existing one) and pass its ARN via var.certificate_arn.
+
+resource "aws_lb_listener" "https" {
+  count = var.certificate_arn != null ? 1 : 0
+
+  load_balancer_arn = aws_lb.this.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = var.ssl_policy
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -1,0 +1,44 @@
+output "alb_id" {
+  description = "The ID of the Application Load Balancer."
+  value       = aws_lb.this.id
+}
+
+output "alb_arn" {
+  description = "The ARN of the Application Load Balancer."
+  value       = aws_lb.this.arn
+}
+
+output "alb_arn_suffix" {
+  description = "The ARN suffix of the ALB. Used as a dimension in CloudWatch metrics."
+  value       = aws_lb.this.arn_suffix
+}
+
+output "alb_dns_name" {
+  description = "The DNS name of the ALB. Point your domain's CNAME or alias record to this value."
+  value       = aws_lb.this.dns_name
+}
+
+output "alb_zone_id" {
+  description = "The canonical hosted zone ID of the ALB. Required when creating Route 53 alias records."
+  value       = aws_lb.this.zone_id
+}
+
+output "target_group_arn" {
+  description = "The ARN of the ALB target group. Pass this to the compute module's target_group_arns variable."
+  value       = aws_lb_target_group.this.arn
+}
+
+output "target_group_arn_suffix" {
+  description = "The ARN suffix of the target group. Used as a dimension in CloudWatch metrics."
+  value       = aws_lb_target_group.this.arn_suffix
+}
+
+output "http_listener_arn" {
+  description = "The ARN of the HTTP (port 80) listener."
+  value       = aws_lb_listener.http.arn
+}
+
+output "https_listener_arn" {
+  description = "The ARN of the HTTPS (port 443) listener. Empty string if no certificate was provided."
+  value       = length(aws_lb_listener.https) > 0 ? aws_lb_listener.https[0].arn : ""
+}

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -1,0 +1,78 @@
+variable "name" {
+  description = "Name prefix for all ALB resources (ALB, target group, listeners)."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID in which the ALB and target group will be created."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of public subnet IDs across multiple AZs. The ALB requires at least two subnets in different AZs."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs to attach to the ALB. The SG should allow inbound 80/443 from the internet."
+  type        = list(string)
+}
+
+variable "internal" {
+  description = "Set to true for an internal (private) ALB. False creates an internet-facing ALB."
+  type        = bool
+  default     = false
+}
+
+variable "enable_deletion_protection" {
+  description = "Prevent accidental deletion of the ALB via the AWS Console or API. Always enable this in production."
+  type        = bool
+  default     = false
+}
+
+variable "idle_timeout" {
+  description = "Time in seconds the ALB waits for a client to send a request before closing the connection."
+  type        = number
+  default     = 60
+}
+
+variable "target_port" {
+  description = "Port on which targets (EC2 instances) receive traffic from the ALB."
+  type        = number
+  default     = 80
+}
+
+variable "health_check_path" {
+  description = "HTTP path the ALB uses to assess target health. The path must return a 2xx or 3xx status."
+  type        = string
+  default     = "/health"
+}
+
+variable "deregistration_delay" {
+  description = "Seconds the ALB waits after a target begins deregistering before completing deregistration. Allows in-flight requests to complete."
+  type        = number
+  default     = 30
+}
+
+variable "certificate_arn" {
+  description = "ACM certificate ARN for HTTPS. When provided, the HTTP listener redirects to HTTPS (301) and an HTTPS listener is created. Leave null to serve HTTP only (suitable for dev/staging without a domain)."
+  type        = string
+  default     = null
+}
+
+variable "ssl_policy" {
+  description = "SSL/TLS negotiation policy for the HTTPS listener. ELBSecurityPolicy-TLS13-1-2-2021-06 is the recommended modern policy."
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all ALB resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/alb/versions.tf
+++ b/modules/alb/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/compute/.terraform.lock.hcl
+++ b/modules/compute/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/compute/README.md
+++ b/modules/compute/README.md
@@ -1,0 +1,164 @@
+# modules/compute
+
+Creates an **EC2 Auto Scaling Group** backed by a **Launch Template**. Designed for running stateless application workloads in private subnets behind an Application Load Balancer.
+
+Key behaviours:
+- **IMDSv2 enforced** — the instance metadata service requires a signed token (`http_tokens = required`) and limits the hop count to 1, preventing SSRF attacks from reaching the metadata API.
+- **EBS encryption** — the root volume is encrypted with a customer-managed KMS key (falls back to the AWS-managed `aws/ebs` key when `kms_key_arn` is not set).
+- **Pinned launch template version** — the ASG is wired to `aws_launch_template.this.latest_version` rather than `$Latest`, ensuring only intentional changes trigger a rolling refresh.
+- **ELB health checks** — when `target_group_arns` is non-empty, the ASG uses ELB health checks so instances failing the ALB health check are replaced, not just EC2-level failures.
+- **Rolling instance refresh** — new launch template versions are rolled out with a 50% minimum healthy percentage, ensuring at least half the fleet remains in service during updates.
+- **`desired_capacity` drift ignored** — external autoscaling policies (target-tracking, scheduled) are allowed to adjust capacity without Terraform overriding them on the next apply.
+
+---
+
+## Usage
+
+### Minimal (no ALB, no KMS)
+
+```hcl
+module "compute" {
+  source = "../../modules/compute"
+
+  name        = "my-app-dev"
+  environment = "dev"
+  ami_id      = data.aws_ami.amazon_linux.id
+  subnet_ids  = module.vpc.private_subnet_ids
+  security_group_ids = [module.app_sg.security_group_id]
+}
+```
+
+### Full (ALB, KMS, IAM profile, user data)
+
+```hcl
+module "compute" {
+  source = "../../modules/compute"
+
+  name        = "my-app-prod"
+  environment = "prod"
+  ami_id      = data.aws_ami.amazon_linux.id
+  instance_type = "t3.medium"
+
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.app_sg.security_group_id]
+
+  iam_instance_profile = module.iam.instance_profile_name
+  kms_key_arn          = module.kms.key_arn
+  target_group_arns    = [module.alb.target_group_arn]
+
+  min_size                 = 2
+  max_size                 = 6
+  desired_capacity         = 2
+  health_check_grace_period = 300
+
+  root_volume_size = 30
+
+  user_data = base64encode(<<-EOF
+    #!/bin/bash
+    yum update -y
+    # ... install and start your application ...
+  EOF
+  )
+}
+```
+
+### Resolving the AMI dynamically
+
+Rather than hardcoding an AMI ID, use a data source:
+
+```hcl
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `name` | Name prefix for all compute resources. | `string` | — | yes |
+| `environment` | Environment name (e.g. dev, staging, prod). | `string` | — | yes |
+| `ami_id` | AMI ID for EC2 instances. Use `aws_ami` data source to avoid hardcoding. | `string` | — | yes |
+| `subnet_ids` | List of private subnet IDs. Should span multiple AZs for HA. | `list(string)` | — | yes |
+| `security_group_ids` | List of security group IDs to attach to EC2 instances. | `list(string)` | — | yes |
+| `instance_type` | EC2 instance type. | `string` | `"t3.micro"` | no |
+| `iam_instance_profile` | Name of the IAM instance profile to attach. Required for SSM Session Manager and CloudWatch agent. | `string` | `null` | no |
+| `min_size` | Minimum number of instances the ASG will maintain. | `number` | `1` | no |
+| `max_size` | Maximum number of instances the ASG can scale to. | `number` | `3` | no |
+| `desired_capacity` | Initial desired instance count. Ignored after first apply (external policies manage this). | `number` | `1` | no |
+| `health_check_grace_period` | Seconds after instance launch before health checks begin. Increase if startup takes longer than the default. | `number` | `300` | no |
+| `target_group_arns` | ALB/NLB target group ARNs. When non-empty, health check type switches to `ELB`. | `list(string)` | `[]` | no |
+| `kms_key_arn` | ARN of the customer-managed KMS key for EBS encryption. When `null`, uses the AWS-managed `aws/ebs` key. | `string` | `null` | no |
+| `key_name` | EC2 key pair name for SSH access. Prefer SSM Session Manager over SSH — no key or open port 22 required. | `string` | `null` | no |
+| `user_data` | Base64-encoded bootstrap script executed on first boot. | `string` | `null` | no |
+| `root_volume_size` | Root EBS volume size in GiB. | `number` | `20` | no |
+| `tags` | Additional tags applied to all resources including instance and volume tag specifications. | `map(string)` | `{}` | no |
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `launch_template_id` | The ID of the launch template. |
+| `launch_template_arn` | The ARN of the launch template. |
+| `autoscaling_group_name` | The name of the Auto Scaling Group. Pass to the monitoring module's `autoscaling_group_name`. |
+| `autoscaling_group_arn` | The ARN of the Auto Scaling Group. |
+
+---
+
+## Notes
+
+### Instance metadata (IMDSv2)
+
+IMDSv2 is enforced with `http_tokens = required` and `http_put_response_hop_limit = 1`. Applications running on these instances must use IMDSv2-compatible SDKs (AWS SDK v2+, AWS CLI v2+). If your application uses `curl http://169.254.169.254/latest/...` directly, update it to use the token-based flow:
+
+```bash
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+curl -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/instance-id
+```
+
+### Instance access via SSM
+
+SSH access is not required (and no security group rule for port 22 is defined). Use AWS Systems Manager Session Manager for shell access:
+
+```bash
+aws ssm start-session --target <instance-id>
+```
+
+The instance profile must include the `AmazonSSMManagedInstanceCore` managed policy.
+
+### Rolling refresh behaviour
+
+When the launch template is updated (e.g. new AMI, new instance type), the ASG performs a rolling instance refresh. At least 50% of instances are kept healthy at all times. The refresh can take several minutes for large fleets.
+
+To trigger a manual refresh after updating the AMI:
+
+```bash
+aws autoscaling start-instance-refresh \
+  --auto-scaling-group-name <asg-name> \
+  --preferences '{"MinHealthyPercentage": 50}'
+```
+
+### `desired_capacity` management
+
+Terraform ignores changes to `desired_capacity` after initial creation. This allows target-tracking and scheduled scaling policies to adjust capacity without being reset on every `terraform apply`. If you need to force a specific capacity, temporarily remove the `ignore_changes` lifecycle rule.

--- a/modules/compute/compute_unit.tftest.hcl
+++ b/modules/compute/compute_unit.tftest.hcl
@@ -48,7 +48,7 @@ run "ebs_encryption_enabled" {
   }
 
   assert {
-    condition     = aws_launch_template.this.block_device_mappings[0].ebs[0].encrypted == true
+    condition     = tobool(aws_launch_template.this.block_device_mappings[0].ebs[0].encrypted) == true
     error_message = "Root EBS volume must always be encrypted."
   }
 }
@@ -86,7 +86,7 @@ run "no_public_ip_assigned" {
   }
 
   assert {
-    condition     = aws_launch_template.this.network_interfaces[0].associate_public_ip_address == false
+    condition     = tobool(aws_launch_template.this.network_interfaces[0].associate_public_ip_address) == false
     error_message = "Instances must not receive public IP addresses — they should be in private subnets behind an ALB."
   }
 }

--- a/modules/compute/compute_unit.tftest.hcl
+++ b/modules/compute/compute_unit.tftest.hcl
@@ -48,7 +48,7 @@ run "ebs_encryption_enabled" {
   }
 
   assert {
-    condition     = tobool(aws_launch_template.this.block_device_mappings[0].ebs[0].encrypted) == true
+    condition     = aws_launch_template.this.block_device_mappings[0].ebs[0].encrypted == true
     error_message = "Root EBS volume must always be encrypted."
   }
 }
@@ -86,7 +86,7 @@ run "no_public_ip_assigned" {
   }
 
   assert {
-    condition     = tobool(aws_launch_template.this.network_interfaces[0].associate_public_ip_address) == false
+    condition     = aws_launch_template.this.network_interfaces[0].associate_public_ip_address == false
     error_message = "Instances must not receive public IP addresses — they should be in private subnets behind an ALB."
   }
 }

--- a/modules/compute/compute_unit.tftest.hcl
+++ b/modules/compute/compute_unit.tftest.hcl
@@ -48,7 +48,7 @@ run "ebs_encryption_enabled" {
   }
 
   assert {
-    condition     = aws_launch_template.this.block_device_mappings[0].ebs[0].encrypted == true
+    condition     = aws_launch_template.this.block_device_mappings[0].ebs[0].encrypted == "true"
     error_message = "Root EBS volume must always be encrypted."
   }
 }
@@ -86,7 +86,7 @@ run "no_public_ip_assigned" {
   }
 
   assert {
-    condition     = aws_launch_template.this.network_interfaces[0].associate_public_ip_address == false
+    condition     = aws_launch_template.this.network_interfaces[0].associate_public_ip_address == "false"
     error_message = "Instances must not receive public IP addresses — they should be in private subnets behind an ALB."
   }
 }

--- a/modules/compute/compute_unit.tftest.hcl
+++ b/modules/compute/compute_unit.tftest.hcl
@@ -1,0 +1,161 @@
+# Unit tests for modules/compute
+# Run with: terraform -chdir=modules/compute test
+
+mock_provider "aws" {}
+
+# ── Test: IMDSv2 is always required ──────────────────────────────────────────
+# IMDSv2 prevents SSRF attacks from reaching the metadata API and must always
+# be enforced. This is a security-critical invariant.
+
+run "imdsv2_required" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "test"
+    ami_id             = "ami-0123456789abcdef0"
+    subnet_ids         = ["subnet-aaaaaaaa", "subnet-bbbbbbbb"]
+    security_group_ids = ["sg-11111111"]
+  }
+
+  assert {
+    condition     = aws_launch_template.this.metadata_options[0].http_tokens == "required"
+    error_message = "http_tokens must be 'required' to enforce IMDSv2. This is a security requirement."
+  }
+
+  assert {
+    condition     = aws_launch_template.this.metadata_options[0].http_endpoint == "enabled"
+    error_message = "http_endpoint must be 'enabled' for IMDSv2 to function."
+  }
+
+  assert {
+    condition     = aws_launch_template.this.metadata_options[0].http_put_response_hop_limit == 1
+    error_message = "hop_limit must be 1 to prevent metadata access from containers on the host."
+  }
+}
+
+# ── Test: EBS volume is always encrypted ─────────────────────────────────────
+
+run "ebs_encryption_enabled" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "test"
+    ami_id             = "ami-0123456789abcdef0"
+    subnet_ids         = ["subnet-aaaaaaaa"]
+    security_group_ids = ["sg-11111111"]
+  }
+
+  assert {
+    condition     = aws_launch_template.this.block_device_mappings[0].ebs[0].encrypted == true
+    error_message = "Root EBS volume must always be encrypted."
+  }
+}
+
+# ── Test: detailed monitoring is always enabled ───────────────────────────────
+
+run "detailed_monitoring_enabled" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "test"
+    ami_id             = "ami-0123456789abcdef0"
+    subnet_ids         = ["subnet-aaaaaaaa"]
+    security_group_ids = ["sg-11111111"]
+  }
+
+  assert {
+    condition     = aws_launch_template.this.monitoring[0].enabled == true
+    error_message = "Detailed EC2 monitoring must always be enabled."
+  }
+}
+
+# ── Test: instances never get public IPs ─────────────────────────────────────
+
+run "no_public_ip_assigned" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "test"
+    ami_id             = "ami-0123456789abcdef0"
+    subnet_ids         = ["subnet-aaaaaaaa"]
+    security_group_ids = ["sg-11111111"]
+  }
+
+  assert {
+    condition     = aws_launch_template.this.network_interfaces[0].associate_public_ip_address == false
+    error_message = "Instances must not receive public IP addresses — they should be in private subnets behind an ALB."
+  }
+}
+
+# ── Test: ELB health checks used when target groups are provided ──────────────
+
+run "elb_health_check_when_target_groups_set" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "test"
+    ami_id             = "ami-0123456789abcdef0"
+    subnet_ids         = ["subnet-aaaaaaaa"]
+    security_group_ids = ["sg-11111111"]
+    target_group_arns  = ["arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/test/abc123"]
+  }
+
+  assert {
+    condition     = aws_autoscaling_group.this.health_check_type == "ELB"
+    error_message = "Health check type must be ELB when target groups are provided."
+  }
+}
+
+# ── Test: EC2 health checks used when no target groups provided ───────────────
+
+run "ec2_health_check_without_target_groups" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "test"
+    ami_id             = "ami-0123456789abcdef0"
+    subnet_ids         = ["subnet-aaaaaaaa"]
+    security_group_ids = ["sg-11111111"]
+    target_group_arns  = []
+  }
+
+  assert {
+    condition     = aws_autoscaling_group.this.health_check_type == "EC2"
+    error_message = "Health check type must be EC2 when no target groups are provided."
+  }
+}
+
+# ── Test: ASG min/max/desired defaults ───────────────────────────────────────
+
+run "asg_size_defaults" {
+  command = plan
+
+  variables {
+    name               = "test-app"
+    environment        = "test"
+    ami_id             = "ami-0123456789abcdef0"
+    subnet_ids         = ["subnet-aaaaaaaa"]
+    security_group_ids = ["sg-11111111"]
+  }
+
+  assert {
+    condition     = aws_autoscaling_group.this.min_size == 1
+    error_message = "Default min_size must be 1."
+  }
+
+  assert {
+    condition     = aws_autoscaling_group.this.max_size == 3
+    error_message = "Default max_size must be 3."
+  }
+
+  assert {
+    condition     = aws_autoscaling_group.this.desired_capacity == 1
+    error_message = "Default desired_capacity must be 1."
+  }
+}

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -1,0 +1,107 @@
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+
+resource "aws_launch_template" "this" {
+  name_prefix   = "${var.name}-"
+  image_id      = var.ami_id
+  instance_type = var.instance_type
+  key_name      = var.key_name
+  user_data     = var.user_data
+
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups             = var.security_group_ids
+    delete_on_termination       = true
+  }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size           = var.root_volume_size
+      volume_type           = "gp3"
+      encrypted             = true
+      delete_on_termination = true
+    }
+  }
+
+  dynamic "iam_instance_profile" {
+    for_each = var.iam_instance_profile != null ? [1] : []
+    content {
+      name = var.iam_instance_profile
+    }
+  }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required" # Enforce IMDSv2
+    http_put_response_hop_limit = 1
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, {
+      Name = var.name
+    })
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(local.common_tags, {
+      Name = "${var.name}-volume"
+    })
+  }
+
+  tags = local.common_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "this" {
+  name_prefix         = "${var.name}-"
+  vpc_zone_identifier = var.subnet_ids
+  min_size            = var.min_size
+  max_size            = var.max_size
+  desired_capacity    = var.desired_capacity
+
+  health_check_type         = "EC2"
+  health_check_grace_period = 300
+
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = "$Latest"
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
+    preferences {
+      min_healthy_percentage = 50
+    }
+  }
+
+  dynamic "tag" {
+    for_each = merge(local.common_tags, { Name = var.name })
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [desired_capacity]
+  }
+}

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -27,6 +27,7 @@ resource "aws_launch_template" "this" {
       volume_size           = var.root_volume_size
       volume_type           = "gp3"
       encrypted             = true
+      kms_key_id            = var.kms_key_arn  # Customer-managed key; null falls back to AWS-managed
       delete_on_termination = true
     }
   }
@@ -38,9 +39,12 @@ resource "aws_launch_template" "this" {
     }
   }
 
+  # IMDSv2 — require signed token requests for the instance metadata service.
+  # This prevents SSRF attacks from being able to reach the metadata API, which
+  # would otherwise expose the instance's IAM credentials.
   metadata_options {
     http_endpoint               = "enabled"
-    http_tokens                 = "required" # Enforce IMDSv2
+    http_tokens                 = "required"
     http_put_response_hop_limit = 1
   }
 
@@ -76,14 +80,24 @@ resource "aws_autoscaling_group" "this" {
   max_size            = var.max_size
   desired_capacity    = var.desired_capacity
 
-  health_check_type         = "EC2"
-  health_check_grace_period = 300
+  # Use ELB health checks when an ALB target group is attached so that
+  # instances failing ALB health checks are replaced — not just EC2 checks.
+  health_check_type         = length(var.target_group_arns) > 0 ? "ELB" : "EC2"
+  health_check_grace_period = var.health_check_grace_period
 
+  # Pin to the specific version created by this apply rather than "$Latest".
+  # Using $Latest means an unrelated launch template update could trigger an
+  # unexpected rolling refresh outside of your planned deployment window.
   launch_template {
     id      = aws_launch_template.this.id
-    version = "$Latest"
+    version = aws_launch_template.this.latest_version
   }
 
+  # Wire up ALB target groups so the ASG registers/deregisters instances automatically.
+  target_group_arns = var.target_group_arns
+
+  # Rolling refresh replaces instances with the new launch template version in
+  # batches, ensuring at least min_healthy_percentage are healthy at all times.
   instance_refresh {
     strategy = "Rolling"
     preferences {
@@ -102,6 +116,9 @@ resource "aws_autoscaling_group" "this" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [desired_capacity]
+    # External autoscaling policies (e.g. scheduled or target-tracking) may
+    # adjust desired_capacity. Ignoring it here prevents Terraform from
+    # fighting those adjustments on every plan.
+    ignore_changes = [desired_capacity]
   }
 }

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -27,7 +27,7 @@ resource "aws_launch_template" "this" {
       volume_size           = var.root_volume_size
       volume_type           = "gp3"
       encrypted             = true
-      kms_key_id            = var.kms_key_arn  # Customer-managed key; null falls back to AWS-managed
+      kms_key_id            = var.kms_key_arn # Customer-managed key; null falls back to AWS-managed
       delete_on_termination = true
     }
   }

--- a/modules/compute/outputs.tf
+++ b/modules/compute/outputs.tf
@@ -1,0 +1,19 @@
+output "launch_template_id" {
+  description = "The ID of the launch template"
+  value       = aws_launch_template.this.id
+}
+
+output "launch_template_arn" {
+  description = "The ARN of the launch template"
+  value       = aws_launch_template.this.arn
+}
+
+output "autoscaling_group_name" {
+  description = "The name of the Auto Scaling Group"
+  value       = aws_autoscaling_group.this.name
+}
+
+output "autoscaling_group_arn" {
+  description = "The ARN of the Auto Scaling Group"
+  value       = aws_autoscaling_group.this.arn
+}

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -1,78 +1,96 @@
 variable "name" {
-  description = "Name prefix for all compute resources"
+  description = "Name prefix for all compute resources (launch template, ASG)."
   type        = string
 }
 
 variable "environment" {
-  description = "Environment name (e.g. dev, staging, prod)"
+  description = "Environment name (e.g. dev, staging, prod)."
   type        = string
 }
 
 variable "ami_id" {
-  description = "AMI ID for EC2 instances"
+  description = "AMI ID for EC2 instances. Use the aws_ami data source to resolve dynamically rather than hardcoding."
   type        = string
 }
 
 variable "instance_type" {
-  description = "EC2 instance type"
+  description = "EC2 instance type (e.g. t3.micro, t3.small, t3.medium)."
   type        = string
   default     = "t3.micro"
 }
 
 variable "subnet_ids" {
-  description = "List of subnet IDs for the Auto Scaling Group"
+  description = "List of private subnet IDs the ASG distributes instances across. Should span multiple AZs."
   type        = list(string)
 }
 
 variable "security_group_ids" {
-  description = "List of security group IDs to attach to instances"
+  description = "List of security group IDs to attach to EC2 instances."
   type        = list(string)
 }
 
 variable "iam_instance_profile" {
-  description = "Name of the IAM instance profile to attach to instances"
+  description = "Name of the IAM instance profile to attach to instances. Required for SSM access and CloudWatch agent."
   type        = string
   default     = null
 }
 
 variable "min_size" {
-  description = "Minimum number of instances in the ASG"
+  description = "Minimum number of instances the ASG will maintain."
   type        = number
   default     = 1
 }
 
 variable "max_size" {
-  description = "Maximum number of instances in the ASG"
+  description = "Maximum number of instances the ASG can scale to."
   type        = number
   default     = 3
 }
 
 variable "desired_capacity" {
-  description = "Desired number of instances in the ASG"
+  description = "Initial desired instance count. Terraform ignores drift after initial creation to allow autoscaling policies to manage this value."
   type        = number
   default     = 1
 }
 
+variable "health_check_grace_period" {
+  description = "Seconds after instance launch before health checks begin. Increase this if your user_data script or application startup takes longer than the default."
+  type        = number
+  default     = 300
+}
+
+variable "target_group_arns" {
+  description = "List of ALB/NLB target group ARNs to associate with the ASG. When non-empty, health_check_type is automatically set to ELB."
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used to encrypt EBS root volumes. When null, AWS uses an AWS-managed key (aws/ebs). Providing a CMK is strongly recommended for production."
+  type        = string
+  default     = null
+}
+
 variable "key_name" {
-  description = "EC2 key pair name for SSH access"
+  description = "EC2 key pair name for SSH access. Prefer SSM Session Manager over SSH where possible — no key or open port 22 required."
   type        = string
   default     = null
 }
 
 variable "user_data" {
-  description = "Base64-encoded user data script to run on instance launch"
+  description = "Base64-encoded user data script executed on first boot. Use this for bootstrapping (install agents, configure app, etc.)."
   type        = string
   default     = null
 }
 
 variable "root_volume_size" {
-  description = "Root EBS volume size in GB"
+  description = "Root EBS volume size in GiB."
   type        = number
   default     = 20
 }
 
 variable "tags" {
-  description = "Additional tags to apply to all resources"
+  description = "Additional tags applied to all resources, including instance and volume tag specifications."
   type        = map(string)
   default     = {}
 }

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -1,0 +1,78 @@
+variable "name" {
+  description = "Name prefix for all compute resources"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instances"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the Auto Scaling Group"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "List of security group IDs to attach to instances"
+  type        = list(string)
+}
+
+variable "iam_instance_profile" {
+  description = "Name of the IAM instance profile to attach to instances"
+  type        = string
+  default     = null
+}
+
+variable "min_size" {
+  description = "Minimum number of instances in the ASG"
+  type        = number
+  default     = 1
+}
+
+variable "max_size" {
+  description = "Maximum number of instances in the ASG"
+  type        = number
+  default     = 3
+}
+
+variable "desired_capacity" {
+  description = "Desired number of instances in the ASG"
+  type        = number
+  default     = 1
+}
+
+variable "key_name" {
+  description = "EC2 key pair name for SSH access"
+  type        = string
+  default     = null
+}
+
+variable "user_data" {
+  description = "Base64-encoded user data script to run on instance launch"
+  type        = string
+  default     = null
+}
+
+variable "root_volume_size" {
+  description = "Root EBS volume size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/compute/versions.tf
+++ b/modules/compute/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/iam/.terraform.lock.hcl
+++ b/modules/iam/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,0 +1,180 @@
+# modules/iam
+
+Creates an **IAM Role** with configurable trust policy, managed policy attachments, inline policies, and an optional EC2 instance profile.
+
+This module is intentionally minimal and composable. It handles the boilerplate of role creation and attachment, while keeping policy content outside the module so callers retain full control over permissions.
+
+---
+
+## Usage
+
+### EC2 instance role with SSM and CloudWatch access
+
+```hcl
+module "app_role" {
+  source = "../../modules/iam"
+
+  role_name   = "my-app-prod-ec2-role"
+  description = "Allows EC2 instances to use SSM Session Manager and publish CloudWatch metrics."
+
+  trust_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+  ]
+
+  create_instance_profile = true
+
+  tags = {
+    Application = "my-app"
+  }
+}
+```
+
+### Role with inline policies
+
+```hcl
+module "app_role" {
+  source = "../../modules/iam"
+
+  role_name    = "my-app-prod-ec2-role"
+  trust_policy = jsonencode({ ... })
+
+  inline_policies = {
+    "s3-access" = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = "${aws_s3_bucket.app.arn}/*"
+      }]
+    })
+
+    "kms-decrypt" = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt", "kms:GenerateDataKey"]
+        Resource = module.kms.key_arn
+      }]
+    })
+  }
+
+  create_instance_profile = true
+}
+```
+
+### Passing the instance profile to the compute module
+
+```hcl
+module "compute" {
+  source = "../../modules/compute"
+
+  # ...
+  iam_instance_profile = module.app_role.instance_profile_name
+}
+```
+
+### Cross-account assume-role
+
+```hcl
+module "cross_account_role" {
+  source = "../../modules/iam"
+
+  role_name    = "ci-deploy-role"
+  description  = "Assumed by GitHub Actions OIDC provider for CI/CD deployments."
+
+  trust_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = "arn:aws:iam::${var.account_id}:oidc-provider/token.actions.githubusercontent.com"
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:<org>/<repo>:*"
+        }
+      }
+    }]
+  })
+
+  policy_arns = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `role_name` | Name of the IAM role. Must be unique within the AWS account. | `string` | — | yes |
+| `trust_policy` | JSON trust policy document defining which principals can assume this role. | `string` | — | yes |
+| `description` | Human-readable description of the role's purpose. | `string` | `"Managed by Terraform"` | no |
+| `policy_arns` | List of AWS managed or customer-managed policy ARNs to attach to the role. | `list(string)` | `[]` | no |
+| `inline_policies` | Map of inline policy name → JSON policy document. Use for resource-specific permissions not suited to managed policies. | `map(string)` | `{}` | no |
+| `create_instance_profile` | Whether to create an EC2 instance profile backed by this role. Set to `true` for roles used by EC2 instances. | `bool` | `false` | no |
+| `tags` | Additional tags to apply to the IAM role. | `map(string)` | `{}` | no |
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `role_arn` | The ARN of the IAM role. Use in trust policies of other roles or resource-based policies. |
+| `role_name` | The name of the IAM role. |
+| `role_id` | The stable, unique role ID (used in IAM conditions). |
+| `instance_profile_arn` | The ARN of the instance profile. `null` if `create_instance_profile = false`. |
+| `instance_profile_name` | The name of the instance profile. `null` if `create_instance_profile = false`. Pass to the compute module's `iam_instance_profile`. |
+
+---
+
+## Notes
+
+### Managed policies vs inline policies
+
+- **Managed policies** (`policy_arns`) are reusable across multiple roles and can be updated independently of this Terraform configuration. Prefer AWS-managed policies where they exist (e.g. `AmazonSSMManagedInstanceCore`).
+- **Inline policies** (`inline_policies`) are tightly coupled to the role. Use inline policies for resource-specific permissions that should not be shared (e.g. access to a specific S3 bucket or KMS key). This makes the role self-documenting — all permissions live in one place.
+
+### Least privilege
+
+Always scope `Resource` in inline policies to the specific ARN rather than `"*"`. Example:
+
+```hcl
+# Good
+Resource = module.kms.key_arn
+
+# Avoid
+Resource = "*"
+```
+
+### Instance profile
+
+IAM instance profiles are the mechanism by which EC2 instances assume an IAM role. The profile name is passed to the launch template. Only one role can be associated with an instance profile, and a role can only be associated with one instance profile at a time.
+
+### Policy propagation delay
+
+IAM is eventually consistent. After `terraform apply`, newly attached policies may take 5–30 seconds to take effect on running instances that have already cached their credentials. For EC2 instances, the instance metadata credential refresh cycle is approximately 5 minutes.

--- a/modules/iam/iam_unit.tftest.hcl
+++ b/modules/iam/iam_unit.tftest.hcl
@@ -3,17 +3,6 @@
 
 mock_provider "aws" {}
 
-locals {
-  ec2_trust_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Principal = { Service = "ec2.amazonaws.com" }
-      Action    = "sts:AssumeRole"
-    }]
-  })
-}
-
 # ── Test: role is created with the correct name ───────────────────────────────
 
 run "role_name_is_set" {
@@ -21,7 +10,7 @@ run "role_name_is_set" {
 
   variables {
     role_name    = "test-ec2-role"
-    trust_policy = local.ec2_trust_policy
+    trust_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
   }
 
   assert {
@@ -37,7 +26,7 @@ run "managed_by_tag_always_present" {
 
   variables {
     role_name    = "test-ec2-role"
-    trust_policy = local.ec2_trust_policy
+    trust_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
   }
 
   assert {
@@ -53,7 +42,7 @@ run "instance_profile_created_when_requested" {
 
   variables {
     role_name               = "test-ec2-role"
-    trust_policy            = local.ec2_trust_policy
+    trust_policy            = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
     create_instance_profile = true
   }
 
@@ -70,7 +59,7 @@ run "instance_profile_not_created_by_default" {
 
   variables {
     role_name    = "test-ec2-role"
-    trust_policy = local.ec2_trust_policy
+    trust_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
   }
 
   assert {
@@ -86,7 +75,7 @@ run "no_attachments_when_policy_arns_empty" {
 
   variables {
     role_name    = "test-ec2-role"
-    trust_policy = local.ec2_trust_policy
+    trust_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
     policy_arns  = []
   }
 
@@ -103,7 +92,7 @@ run "policy_attachments_created_for_each_arn" {
 
   variables {
     role_name    = "test-ec2-role"
-    trust_policy = local.ec2_trust_policy
+    trust_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
     policy_arns = [
       "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
       "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",

--- a/modules/iam/iam_unit.tftest.hcl
+++ b/modules/iam/iam_unit.tftest.hcl
@@ -1,0 +1,117 @@
+# Unit tests for modules/iam
+# Run with: terraform -chdir=modules/iam test
+
+mock_provider "aws" {}
+
+locals {
+  ec2_trust_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+# ── Test: role is created with the correct name ───────────────────────────────
+
+run "role_name_is_set" {
+  command = plan
+
+  variables {
+    role_name    = "test-ec2-role"
+    trust_policy = local.ec2_trust_policy
+  }
+
+  assert {
+    condition     = aws_iam_role.this.name == "test-ec2-role"
+    error_message = "IAM role name must match the role_name variable."
+  }
+}
+
+# ── Test: ManagedBy tag is always applied ─────────────────────────────────────
+
+run "managed_by_tag_always_present" {
+  command = plan
+
+  variables {
+    role_name    = "test-ec2-role"
+    trust_policy = local.ec2_trust_policy
+  }
+
+  assert {
+    condition     = aws_iam_role.this.tags["ManagedBy"] == "Terraform"
+    error_message = "ManagedBy=Terraform tag must always be applied to the IAM role."
+  }
+}
+
+# ── Test: instance profile is created when requested ─────────────────────────
+
+run "instance_profile_created_when_requested" {
+  command = plan
+
+  variables {
+    role_name               = "test-ec2-role"
+    trust_policy            = local.ec2_trust_policy
+    create_instance_profile = true
+  }
+
+  assert {
+    condition     = length(aws_iam_instance_profile.this) == 1
+    error_message = "Instance profile must be created when create_instance_profile = true."
+  }
+}
+
+# ── Test: instance profile is NOT created by default ─────────────────────────
+
+run "instance_profile_not_created_by_default" {
+  command = plan
+
+  variables {
+    role_name    = "test-ec2-role"
+    trust_policy = local.ec2_trust_policy
+  }
+
+  assert {
+    condition     = length(aws_iam_instance_profile.this) == 0
+    error_message = "Instance profile must not be created unless create_instance_profile = true."
+  }
+}
+
+# ── Test: no policy attachments when policy_arns is empty ────────────────────
+
+run "no_attachments_when_policy_arns_empty" {
+  command = plan
+
+  variables {
+    role_name    = "test-ec2-role"
+    trust_policy = local.ec2_trust_policy
+    policy_arns  = []
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.this) == 0
+    error_message = "No policy attachments should be created when policy_arns is empty."
+  }
+}
+
+# ── Test: correct number of policy attachments ────────────────────────────────
+
+run "policy_attachments_created_for_each_arn" {
+  command = plan
+
+  variables {
+    role_name    = "test-ec2-role"
+    trust_policy = local.ec2_trust_policy
+    policy_arns = [
+      "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+      "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+    ]
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy_attachment.this) == 2
+    error_message = "One policy attachment must be created per ARN in policy_arns."
+  }
+}

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_role" "this" {
+  name               = var.role_name
+  description        = var.description
+  assume_role_policy = var.trust_policy
+
+  tags = merge({ ManagedBy = "Terraform" }, var.tags)
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each = toset(var.policy_arns)
+
+  role       = aws_iam_role.this.name
+  policy_arn = each.value
+}
+
+resource "aws_iam_role_policy" "this" {
+  for_each = var.inline_policies
+
+  name   = each.key
+  role   = aws_iam_role.this.id
+  policy = each.value
+}
+
+resource "aws_iam_instance_profile" "this" {
+  count = var.create_instance_profile ? 1 : 0
+
+  name = var.role_name
+  role = aws_iam_role.this.name
+}

--- a/modules/iam/outputs.tf
+++ b/modules/iam/outputs.tf
@@ -1,0 +1,24 @@
+output "role_arn" {
+  description = "The ARN of the IAM role"
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "The name of the IAM role"
+  value       = aws_iam_role.this.name
+}
+
+output "role_id" {
+  description = "The stable and unique string identifying the role"
+  value       = aws_iam_role.this.id
+}
+
+output "instance_profile_arn" {
+  description = "The ARN of the instance profile (null if not created)"
+  value       = var.create_instance_profile ? aws_iam_instance_profile.this[0].arn : null
+}
+
+output "instance_profile_name" {
+  description = "The name of the instance profile (null if not created)"
+  value       = var.create_instance_profile ? aws_iam_instance_profile.this[0].name : null
+}

--- a/modules/iam/variables.tf
+++ b/modules/iam/variables.tf
@@ -1,0 +1,39 @@
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the IAM role"
+  type        = string
+  default     = "Managed by Terraform"
+}
+
+variable "trust_policy" {
+  description = "JSON trust policy document (who can assume this role)"
+  type        = string
+}
+
+variable "policy_arns" {
+  description = "List of managed IAM policy ARNs to attach to the role"
+  type        = list(string)
+  default     = []
+}
+
+variable "inline_policies" {
+  description = "Map of inline policy name => JSON policy document"
+  type        = map(string)
+  default     = {}
+}
+
+variable "create_instance_profile" {
+  description = "Whether to create an EC2 instance profile for this role"
+  type        = bool
+  default     = false
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the role"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/iam/versions.tf
+++ b/modules/iam/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/kms/.terraform.lock.hcl
+++ b/modules/kms/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/kms/README.md
+++ b/modules/kms/README.md
@@ -1,0 +1,125 @@
+# Module: kms
+
+Creates a customer-managed AWS KMS key (CMK) with automatic annual key rotation, a human-readable alias, and a least-privilege key policy. The module is the encryption foundation for this infrastructure — the same key ARN is consumed by the `storage` module (S3 SSE) and the `compute` module (EBS volume encryption).
+
+## Architecture Notes
+
+- **Key rotation** is always enabled (`enable_key_rotation = true`). AWS automatically generates new backing key material every 365 days. Existing ciphertexts continue to decrypt transparently; the Key ID and alias remain unchanged.
+- **Key policy** follows a two-statement least-privilege model:
+  1. The account root principal (`arn:aws:iam::<account_id>:root`) receives full `kms:*` access as a break-glass backstop.
+  2. The identity running Terraform receives administrative actions (create, rotate, disable, delete, tag). Service principals that _use_ the key (S3, EBS) are granted access via IAM policies on their respective roles — not in the key policy itself — keeping the blast radius small.
+- A custom policy can be supplied via `var.key_policy` to override the default entirely (e.g., to grant cross-account access or add a service principal directly).
+- **Multi-region keys** are opt-in (`multi_region = false` by default). Enable this only when you need to replicate encrypted objects to another region without re-encrypting them.
+- The **deletion window** defaults to 30 days. AWS will not immediately delete the key when `terraform destroy` is run; the pending deletion can be cancelled during that window. Minimum is 7 days; maximum is 30.
+
+## Prerequisites
+
+| Requirement | Version |
+|---|---|
+| Terraform | `>= 1.3` |
+| AWS Provider | `>= 5.0` |
+| IAM permissions | `kms:CreateKey`, `kms:CreateAlias`, `kms:PutKeyPolicy`, `kms:TagResource`, `kms:EnableKeyRotation` |
+
+The Terraform identity must have permission to call `sts:GetCallerIdentity` so the module can inject the caller's ARN into the default key policy.
+
+## Usage
+
+```hcl
+module "kms" {
+  source = "../../modules/kms"
+
+  alias_name              = "prod-app"
+  description             = "Customer-managed key for prod S3 and EBS encryption"
+  environment             = "prod"
+  deletion_window_in_days = 30
+  tags = {
+    Project = "demo"
+    Owner   = "platform-team"
+  }
+}
+```
+
+Reference the outputs in downstream modules:
+
+```hcl
+module "app_storage" {
+  source      = "../../modules/storage"
+  kms_key_arn = module.kms.key_arn
+  # ...
+}
+
+module "app_compute" {
+  source      = "../../modules/compute"
+  kms_key_arn = module.kms.key_arn
+  # ...
+}
+```
+
+### Custom Key Policy Example
+
+```hcl
+module "kms" {
+  source = "../../modules/kms"
+
+  alias_name   = "prod-app"
+  description  = "CMK with cross-account access"
+  environment  = "prod"
+
+  key_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "RootAccess"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::111122223333:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "CrossAccountRead"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::444455556666:role/reader" }
+        Action    = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource  = "*"
+      }
+    ]
+  })
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| `alias_name` | KMS key alias (without the `alias/` prefix). Used in logs and the AWS Console. Example: `prod-app`. | `string` | — | yes |
+| `description` | Human-readable description of the key's purpose. | `string` | — | yes |
+| `environment` | Environment name (e.g. dev, staging, prod). Used as a tag. | `string` | — | yes |
+| `deletion_window_in_days` | Waiting period before key deletion takes effect (7–30 days). AWS will not immediately delete the key when destroy is run. | `number` | `30` | no |
+| `multi_region` | Create a multi-region primary key. Required for cross-region replication use cases. Defaults to false. | `bool` | `false` | no |
+| `key_policy` | Custom IAM key policy document (JSON string). If null, a sensible default policy granting root and caller identity access is applied. | `string` | `null` | no |
+| `tags` | Additional tags to apply to the key and alias. | `map(string)` | `{}` | no |
+
+### Validation
+
+`deletion_window_in_days` is validated to be between 7 and 30 (inclusive). Values outside this range will produce an error at plan time.
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `key_id` | The globally unique KMS key ID (UUID format). |
+| `key_arn` | The ARN of the KMS key. Use this when referencing the key in IAM policies or resource encryption configurations. |
+| `alias_arn` | The ARN of the KMS alias. |
+| `alias_name` | The full alias name including the `alias/` prefix (e.g. `alias/prod-app`). |
+
+## Important Notes and Gotchas
+
+**Key deletion is irreversible.** Once the deletion window expires, all data encrypted with that key becomes permanently unrecoverable. Set a generous `deletion_window_in_days` in production (the default of 30 is recommended) and enable a CloudWatch alarm on the `aws_kms_key` `KeyDeletion` event if your security posture requires it.
+
+**Service principal access is not in this key policy by default.** If an EC2 instance or S3 bucket receives a "KMS access denied" error, the fix is to add a `kms:GenerateDataKey` / `kms:Decrypt` statement to the _IAM policy attached to the service role_ — not to the key policy. The key policy's root statement delegates all authorization decisions to IAM, which is the recommended pattern.
+
+**Aliases are globally namespaced within an account and region.** Two keys in the same account/region cannot share an alias. Choose an alias that clearly identifies the environment and workload (e.g. `prod-app`, `staging-rds`).
+
+**Multi-region keys cannot be converted to single-region after creation** and vice versa. Plan your replication strategy before deploying.
+
+**`terraform destroy` does not immediately delete the key.** The key enters a pending-deletion state for `deletion_window_in_days` days. Any resources still encrypted with the key will fail to access their data during and after this window.

--- a/modules/kms/kms_unit.tftest.hcl
+++ b/modules/kms/kms_unit.tftest.hcl
@@ -1,0 +1,157 @@
+# Unit tests for modules/kms
+# Run with: terraform -chdir=modules/kms test
+#
+# These tests use mock providers so no AWS credentials or live resources are needed.
+# They validate variable constraints, resource configuration, and output wiring.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:user/test-deployer"
+      user_id    = "AIDAEXAMPLEUSERID"
+    }
+  }
+}
+
+# ── Test: default configuration ───────────────────────────────────────────────
+
+run "creates_key_with_defaults" {
+  command = plan
+
+  variables {
+    alias_name  = "test-app"
+    description = "Test KMS key"
+    environment = "test"
+  }
+
+  assert {
+    condition     = aws_kms_key.this.enable_key_rotation == true
+    error_message = "Key rotation must be enabled by default."
+  }
+
+  assert {
+    condition     = aws_kms_key.this.deletion_window_in_days == 30
+    error_message = "Default deletion window should be 30 days."
+  }
+
+  assert {
+    condition     = aws_kms_key.this.multi_region == false
+    error_message = "Multi-region should be disabled by default."
+  }
+
+  assert {
+    condition     = aws_kms_alias.this.name == "alias/test-app"
+    error_message = "Alias must be prefixed with 'alias/'."
+  }
+}
+
+# ── Test: output wiring ───────────────────────────────────────────────────────
+
+run "outputs_are_wired_correctly" {
+  command = plan
+
+  variables {
+    alias_name  = "prod-app"
+    description = "Production application key"
+    environment = "prod"
+  }
+
+  assert {
+    condition     = output.alias_name == "alias/prod-app"
+    error_message = "alias_name output should include the 'alias/' prefix."
+  }
+}
+
+# ── Test: deletion window validation ─────────────────────────────────────────
+
+run "rejects_deletion_window_below_7" {
+  command = plan
+
+  variables {
+    alias_name              = "test-app"
+    description             = "Test key"
+    environment             = "test"
+    deletion_window_in_days = 6
+  }
+
+  expect_failures = [var.deletion_window_in_days]
+}
+
+run "rejects_deletion_window_above_30" {
+  command = plan
+
+  variables {
+    alias_name              = "test-app"
+    description             = "Test key"
+    environment             = "test"
+    deletion_window_in_days = 31
+  }
+
+  expect_failures = [var.deletion_window_in_days]
+}
+
+run "accepts_minimum_deletion_window" {
+  command = plan
+
+  variables {
+    alias_name              = "dev-app"
+    description             = "Dev key with minimum window"
+    environment             = "dev"
+    deletion_window_in_days = 7
+  }
+
+  assert {
+    condition     = aws_kms_key.this.deletion_window_in_days == 7
+    error_message = "Should accept deletion window of 7 days."
+  }
+}
+
+# ── Test: custom key policy ───────────────────────────────────────────────────
+
+run "accepts_custom_key_policy" {
+  command = plan
+
+  variables {
+    alias_name  = "custom-policy-key"
+    description = "Key with custom policy"
+    environment = "prod"
+    key_policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Sid       = "AllowRoot"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::123456789012:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      }]
+    })
+  }
+
+  assert {
+    condition     = aws_kms_key.this.enable_key_rotation == true
+    error_message = "Key rotation must be enabled even when using a custom policy."
+  }
+}
+
+# ── Test: tagging ─────────────────────────────────────────────────────────────
+
+run "applies_environment_tag" {
+  command = plan
+
+  variables {
+    alias_name  = "tagged-key"
+    description = "Key with environment tag"
+    environment = "staging"
+  }
+
+  assert {
+    condition     = aws_kms_key.this.tags["Environment"] == "staging"
+    error_message = "Environment tag must match the environment variable."
+  }
+
+  assert {
+    condition     = aws_kms_key.this.tags["ManagedBy"] == "Terraform"
+    error_message = "ManagedBy tag must be set to 'Terraform'."
+  }
+}

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -1,0 +1,72 @@
+# Retrieve the current caller's identity so we can grant them key admin rights
+# without hardcoding an ARN. This works correctly for both IAM users and assumed roles.
+data "aws_caller_identity" "current" {}
+
+# Customer-managed KMS key with automatic annual rotation.
+# Rotation generates a new backing key material but keeps the same Key ID and alias,
+# so existing ciphertexts continue to decrypt without any application changes.
+resource "aws_kms_key" "this" {
+  description             = var.description
+  deletion_window_in_days = var.deletion_window_in_days
+  enable_key_rotation     = true  # Rotate the backing key material every 365 days
+  multi_region            = var.multi_region
+
+  # The key policy follows least-privilege: the root account retains full emergency
+  # access, and the deploying identity is granted administrative rights. AWS services
+  # that need to use the key (e.g. S3, EBS) are granted via IAM policies on their
+  # principals — not here — which keeps the blast radius small.
+  policy = var.key_policy != null ? var.key_policy : jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableRootAccountFullAccess"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowKeyAdministration"
+        Effect = "Allow"
+        Principal = {
+          AWS = data.aws_caller_identity.current.arn
+        }
+        Action = [
+          "kms:Create*",
+          "kms:Describe*",
+          "kms:Enable*",
+          "kms:List*",
+          "kms:Put*",
+          "kms:Update*",
+          "kms:Revoke*",
+          "kms:Disable*",
+          "kms:Get*",
+          "kms:Delete*",
+          "kms:TagResource",
+          "kms:UntagResource",
+          "kms:ScheduleKeyDeletion",
+          "kms:CancelKeyDeletion",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = merge(
+    {
+      Name        = var.alias_name
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+
+# Human-readable alias. KMS key IDs are UUID-style and impossible to identify
+# at a glance. An alias like alias/prod-app makes audit logs readable.
+resource "aws_kms_alias" "this" {
+  name          = "alias/${var.alias_name}"
+  target_key_id = aws_kms_key.this.key_id
+}

--- a/modules/kms/main.tf
+++ b/modules/kms/main.tf
@@ -8,7 +8,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_kms_key" "this" {
   description             = var.description
   deletion_window_in_days = var.deletion_window_in_days
-  enable_key_rotation     = true  # Rotate the backing key material every 365 days
+  enable_key_rotation     = true # Rotate the backing key material every 365 days
   multi_region            = var.multi_region
 
   # The key policy follows least-privilege: the root account retains full emergency

--- a/modules/kms/outputs.tf
+++ b/modules/kms/outputs.tf
@@ -1,0 +1,19 @@
+output "key_id" {
+  description = "The globally unique KMS key ID (UUID format)."
+  value       = aws_kms_key.this.key_id
+}
+
+output "key_arn" {
+  description = "The ARN of the KMS key. Use this when referencing the key in IAM policies or resource encryption configurations."
+  value       = aws_kms_key.this.arn
+}
+
+output "alias_arn" {
+  description = "The ARN of the KMS alias."
+  value       = aws_kms_alias.this.arn
+}
+
+output "alias_name" {
+  description = "The full alias name including the 'alias/' prefix (e.g. alias/prod-app)."
+  value       = aws_kms_alias.this.name
+}

--- a/modules/kms/variables.tf
+++ b/modules/kms/variables.tf
@@ -1,0 +1,43 @@
+variable "alias_name" {
+  description = "KMS key alias (without the 'alias/' prefix). Used in logs and the AWS Console. Example: prod-app."
+  type        = string
+}
+
+variable "description" {
+  description = "Human-readable description of the key's purpose."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod). Used as a tag."
+  type        = string
+}
+
+variable "deletion_window_in_days" {
+  description = "Waiting period before key deletion takes effect (7–30 days). AWS will not immediately delete the key when destroy is run."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.deletion_window_in_days >= 7 && var.deletion_window_in_days <= 30
+    error_message = "deletion_window_in_days must be between 7 and 30."
+  }
+}
+
+variable "multi_region" {
+  description = "Create a multi-region primary key. Required for cross-region replication use cases. Defaults to false."
+  type        = bool
+  default     = false
+}
+
+variable "key_policy" {
+  description = "Custom IAM key policy document (JSON string). If null, a sensible default policy granting root and caller identity access is applied."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the key and alias."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/kms/versions.tf
+++ b/modules/kms/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/monitoring/.terraform.lock.hcl
+++ b/modules/monitoring/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/monitoring/README.md
+++ b/modules/monitoring/README.md
@@ -1,0 +1,140 @@
+# modules/monitoring
+
+Creates a **CloudWatch alarm suite** and an **SNS topic** for operational alerting. All alarms publish to a single SNS topic, which can be subscribed by email, PagerDuty, Slack (via Lambda), or any other supported protocol.
+
+Alarms covered:
+- **EC2 CPU utilisation** — warning (default 70%) and critical (default 90%) thresholds, evaluated over 10 minutes.
+- **EC2 status check failures** — triggers immediately on any instance or system-level failure.
+- **ALB 5xx error count** — flags application errors and backend timeouts (optional — requires `alb_arn_suffix`).
+- **ALB unhealthy host count** — alerts when the target group has unhealthy instances (optional — requires both ALB and TG ARN suffixes).
+- **ALB p99 response time** — flags backend latency degradation (optional — requires `alb_arn_suffix`).
+
+All alarms use `treat_missing_data = "notBreaching"` to avoid false-positive alerts during partial outages or CloudWatch metric delivery delays.
+
+---
+
+## Usage
+
+### EC2 alarms only (no ALB)
+
+```hcl
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  name                   = "my-app-dev"
+  environment            = "dev"
+  autoscaling_group_name = module.compute.autoscaling_group_name
+  alarm_email            = "ops@example.com"
+}
+```
+
+### Full suite (EC2 + ALB alarms)
+
+```hcl
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  name                   = "my-app-prod"
+  environment            = "prod"
+  autoscaling_group_name = module.compute.autoscaling_group_name
+  alarm_email            = "oncall@example.com"
+
+  # ALB alarms require these two values from the ALB module outputs
+  alb_arn_suffix          = module.alb.alb_arn_suffix
+  target_group_arn_suffix = module.alb.target_group_arn_suffix
+
+  # Tighter thresholds for production
+  cpu_warning_threshold       = 60
+  cpu_critical_threshold      = 80
+  alb_5xx_threshold           = 5
+  alb_response_time_threshold = 1
+}
+```
+
+### Adding additional SNS subscriptions
+
+The SNS topic ARN is exported. Use it to add subscriptions outside this module (e.g. a PagerDuty or Slack integration):
+
+```hcl
+resource "aws_sns_topic_subscription" "pagerduty" {
+  topic_arn = module.monitoring.sns_topic_arn
+  protocol  = "https"
+  endpoint  = "https://events.pagerduty.com/integration/<key>/enqueue"
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `name` | Name prefix for all monitoring resources. | `string` | — | yes |
+| `environment` | Environment name (e.g. dev, staging, prod). | `string` | — | yes |
+| `autoscaling_group_name` | Name of the Auto Scaling Group to monitor. Comes from `module.compute.autoscaling_group_name`. | `string` | — | yes |
+| `alarm_email` | Email address for alarm notifications. A subscription confirmation email is sent automatically. Set to `null` to skip email subscription. | `string` | `null` | no |
+| `cpu_warning_threshold` | CPU utilisation (%) that triggers the warning alarm. Evaluated over two 5-minute periods. | `number` | `70` | no |
+| `cpu_critical_threshold` | CPU utilisation (%) that triggers the critical alarm. Evaluated over two 5-minute periods. | `number` | `90` | no |
+| `alb_arn_suffix` | ARN suffix of the ALB (from `module.alb.alb_arn_suffix`). ALB alarms are skipped when `null`. | `string` | `null` | no |
+| `target_group_arn_suffix` | ARN suffix of the ALB target group (from `module.alb.target_group_arn_suffix`). Required for the unhealthy host alarm. | `string` | `null` | no |
+| `alb_5xx_threshold` | Number of ALB 5xx responses per minute that triggers the error alarm. | `number` | `10` | no |
+| `alb_response_time_threshold` | ALB p99 target response time in seconds that triggers the latency alarm. | `number` | `3` | no |
+| `tags` | Additional tags applied to all monitoring resources. | `map(string)` | `{}` | no |
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `sns_topic_arn` | The ARN of the SNS alarm topic. Use to add additional subscriptions. |
+| `sns_topic_name` | The name of the SNS alarm topic. |
+| `cpu_warning_alarm_arn` | ARN of the CPU warning CloudWatch alarm. |
+| `cpu_critical_alarm_arn` | ARN of the CPU critical CloudWatch alarm. |
+| `status_check_alarm_arn` | ARN of the EC2 status check CloudWatch alarm. |
+
+---
+
+## Alarm Reference
+
+| Alarm | Metric | Threshold | Evaluation | Action |
+|-------|--------|-----------|------------|--------|
+| `<name>-cpu-warning` | `CPUUtilization` (ASG) | > `cpu_warning_threshold`% | 2 × 5 min | SNS |
+| `<name>-cpu-critical` | `CPUUtilization` (ASG) | > `cpu_critical_threshold`% | 2 × 5 min | SNS |
+| `<name>-status-check-failed` | `StatusCheckFailed` (ASG) | > 0 | 1 × 1 min | SNS |
+| `<name>-alb-5xx` | `HTTPCode_ELB_5XX_Count` (ALB) | > `alb_5xx_threshold` | 1 × 1 min | SNS |
+| `<name>-unhealthy-hosts` | `UnHealthyHostCount` (ALB+TG) | > 0 | 1 × 1 min | SNS |
+| `<name>-high-response-time` | `TargetResponseTime` p99 (ALB) | > `alb_response_time_threshold` s | 2 × 1 min | SNS |
+
+---
+
+## Notes
+
+### Email subscription confirmation
+
+When `alarm_email` is set, AWS SNS sends a subscription confirmation email to the address. **The subscription remains in `PendingConfirmation` state until the recipient clicks the confirm link.** Alarms are not delivered to unconfirmed subscriptions. Confirm the subscription before relying on email alerting.
+
+### Recommended threshold tuning
+
+The default thresholds are conservative starting points. Tune them based on your application's observed behaviour:
+
+- **CPU thresholds** — set warning at ~20% below your target CPU for scaling policies, and critical at the actual degradation point.
+- **Response time threshold** — set based on your application's SLA. A p99 of 1s is reasonable for most web applications.
+- **5xx threshold** — set based on normal error rates. A threshold of 0 is too noisy; 5–10 per minute is a useful starting point.
+
+### ALB alarms and missing data
+
+ALB metrics are only published when the ALB receives traffic. During periods of zero traffic, `HTTPCode_ELB_5XX_Count` and `TargetResponseTime` have no data points. `treat_missing_data = "notBreaching"` prevents these alarms from firing spuriously in low-traffic environments.
+
+### Extending with composite alarms
+
+For more sophisticated alerting (e.g. "alert only when CPU is high AND unhealthy hosts > 0"), use `aws_cloudwatch_composite_alarm` referencing the ARNs exported by this module.

--- a/modules/monitoring/main.tf
+++ b/modules/monitoring/main.tf
@@ -1,0 +1,183 @@
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+
+# ── SNS Topic ─────────────────────────────────────────────────────────────────
+# All CloudWatch alarms in this module publish to a single SNS topic.
+# Operators subscribe to this topic via email, PagerDuty, Slack (via Lambda), etc.
+
+resource "aws_sns_topic" "alarms" {
+  name = "${var.name}-alarms"
+  tags = local.common_tags
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  count = var.alarm_email != null ? 1 : 0
+
+  topic_arn = aws_sns_topic.alarms.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+# ── EC2 / ASG Alarms ──────────────────────────────────────────────────────────
+
+# Warning: CPU above 70% for two consecutive 5-minute periods.
+# This gives you advance notice before the critical threshold is breached,
+# providing time to scale out or investigate.
+resource "aws_cloudwatch_metric_alarm" "cpu_high_warning" {
+  alarm_name          = "${var.name}-cpu-warning"
+  alarm_description   = "CPU utilisation has been above ${var.cpu_warning_threshold}% for 10 minutes. Consider scaling out."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.cpu_warning_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    AutoScalingGroupName = var.autoscaling_group_name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+
+  tags = local.common_tags
+}
+
+# Critical: CPU above 90% for two consecutive 5-minute periods.
+# At this threshold the application is likely degraded and immediate action is required.
+resource "aws_cloudwatch_metric_alarm" "cpu_high_critical" {
+  alarm_name          = "${var.name}-cpu-critical"
+  alarm_description   = "CRITICAL: CPU utilisation has been above ${var.cpu_critical_threshold}% for 10 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.cpu_critical_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    AutoScalingGroupName = var.autoscaling_group_name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+
+  tags = local.common_tags
+}
+
+# EC2 status check failure: catches both instance-level and system-level failures.
+# A single occurrence triggers the alarm — status check failures are always actionable.
+resource "aws_cloudwatch_metric_alarm" "instance_status_check" {
+  alarm_name          = "${var.name}-status-check-failed"
+  alarm_description   = "One or more EC2 instances failed a status check. Instance may require recovery or replacement."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    AutoScalingGroupName = var.autoscaling_group_name
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+
+  tags = local.common_tags
+}
+
+# ── ALB Alarms ────────────────────────────────────────────────────────────────
+# These alarms are only created when alb_arn_suffix and target_group_arn_suffix
+# are provided (i.e. when an ALB is configured).
+
+# 5xx error rate: application errors or backend timeouts above 1% are flagged.
+# This is the most reliable leading indicator of user-facing degradation.
+resource "aws_cloudwatch_metric_alarm" "alb_5xx_errors" {
+  count = var.alb_arn_suffix != null ? 1 : 0
+
+  alarm_name          = "${var.name}-alb-5xx"
+  alarm_description   = "ALB 5XX error count exceeded ${var.alb_5xx_threshold} in the last minute. Check application logs."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = var.alb_5xx_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+
+  tags = local.common_tags
+}
+
+# Unhealthy host count: alerts when the ALB has no healthy targets.
+# This is the most critical ALB alarm — zero healthy hosts means 100% of traffic fails.
+resource "aws_cloudwatch_metric_alarm" "alb_unhealthy_hosts" {
+  count = var.alb_arn_suffix != null && var.target_group_arn_suffix != null ? 1 : 0
+
+  alarm_name          = "${var.name}-unhealthy-hosts"
+  alarm_description   = "CRITICAL: ALB target group has unhealthy hosts. Traffic may be failing."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+    TargetGroup  = var.target_group_arn_suffix
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+
+  tags = local.common_tags
+}
+
+# Target response time: p99 latency above 3 seconds signals backend degradation.
+resource "aws_cloudwatch_metric_alarm" "alb_response_time" {
+  count = var.alb_arn_suffix != null ? 1 : 0
+
+  alarm_name          = "${var.name}-high-response-time"
+  alarm_description   = "ALB p99 target response time exceeded ${var.alb_response_time_threshold}s. Backend may be overloaded."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  extended_statistic  = "p99"
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  threshold           = var.alb_response_time_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    LoadBalancer = var.alb_arn_suffix
+  }
+
+  alarm_actions = [aws_sns_topic.alarms.arn]
+  ok_actions    = [aws_sns_topic.alarms.arn]
+
+  tags = local.common_tags
+}

--- a/modules/monitoring/monitoring_unit.tftest.hcl
+++ b/modules/monitoring/monitoring_unit.tftest.hcl
@@ -78,10 +78,10 @@ run "alb_alarms_skipped_without_alb" {
   command = plan
 
   variables {
-    name                   = "test-app"
-    environment            = "test"
-    autoscaling_group_name = "test-app-asg"
-    alb_arn_suffix         = null
+    name                    = "test-app"
+    environment             = "test"
+    autoscaling_group_name  = "test-app-asg"
+    alb_arn_suffix          = null
     target_group_arn_suffix = null
   }
 

--- a/modules/monitoring/monitoring_unit.tftest.hcl
+++ b/modules/monitoring/monitoring_unit.tftest.hcl
@@ -15,8 +15,8 @@ run "sns_topic_always_created" {
   }
 
   assert {
-    condition     = aws_sns_topic.alarms != null
-    error_message = "SNS alarms topic must always be created."
+    condition     = aws_sns_topic.alarms.name == "test-app-alarms"
+    error_message = "SNS topic name must be '<name>-alarms'."
   }
 }
 
@@ -69,25 +69,6 @@ run "cpu_critical_threshold_default" {
   assert {
     condition     = aws_cloudwatch_metric_alarm.cpu_high_critical.threshold == 90
     error_message = "CPU critical threshold must default to 90."
-  }
-}
-
-# ── Test: warning threshold must be lower than critical ───────────────────────
-
-run "warning_threshold_lower_than_critical" {
-  command = plan
-
-  variables {
-    name                   = "test-app"
-    environment            = "test"
-    autoscaling_group_name = "test-app-asg"
-    cpu_warning_threshold  = 70
-    cpu_critical_threshold = 90
-  }
-
-  assert {
-    condition     = aws_cloudwatch_metric_alarm.cpu_high_warning.threshold < aws_cloudwatch_metric_alarm.cpu_high_critical.threshold
-    error_message = "CPU warning threshold must be lower than the critical threshold."
   }
 }
 

--- a/modules/monitoring/monitoring_unit.tftest.hcl
+++ b/modules/monitoring/monitoring_unit.tftest.hcl
@@ -1,0 +1,150 @@
+# Unit tests for modules/monitoring
+# Run with: terraform -chdir=modules/monitoring test
+
+mock_provider "aws" {}
+
+# ── Test: SNS topic is always created ────────────────────────────────────────
+
+run "sns_topic_always_created" {
+  command = plan
+
+  variables {
+    name                   = "test-app"
+    environment            = "test"
+    autoscaling_group_name = "test-app-asg"
+  }
+
+  assert {
+    condition     = aws_sns_topic.alarms != null
+    error_message = "SNS alarms topic must always be created."
+  }
+}
+
+# ── Test: email subscription skipped when alarm_email is null ─────────────────
+
+run "no_email_subscription_when_null" {
+  command = plan
+
+  variables {
+    name                   = "test-app"
+    environment            = "test"
+    autoscaling_group_name = "test-app-asg"
+    alarm_email            = null
+  }
+
+  assert {
+    condition     = length(aws_sns_topic_subscription.email) == 0
+    error_message = "No email subscription should be created when alarm_email is null."
+  }
+}
+
+# ── Test: CPU warning threshold defaults to 70% ───────────────────────────────
+
+run "cpu_warning_threshold_default" {
+  command = plan
+
+  variables {
+    name                   = "test-app"
+    environment            = "test"
+    autoscaling_group_name = "test-app-asg"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.cpu_high_warning.threshold == 70
+    error_message = "CPU warning threshold must default to 70."
+  }
+}
+
+# ── Test: CPU critical threshold defaults to 90% ─────────────────────────────
+
+run "cpu_critical_threshold_default" {
+  command = plan
+
+  variables {
+    name                   = "test-app"
+    environment            = "test"
+    autoscaling_group_name = "test-app-asg"
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.cpu_high_critical.threshold == 90
+    error_message = "CPU critical threshold must default to 90."
+  }
+}
+
+# ── Test: warning threshold must be lower than critical ───────────────────────
+
+run "warning_threshold_lower_than_critical" {
+  command = plan
+
+  variables {
+    name                   = "test-app"
+    environment            = "test"
+    autoscaling_group_name = "test-app-asg"
+    cpu_warning_threshold  = 70
+    cpu_critical_threshold = 90
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.cpu_high_warning.threshold < aws_cloudwatch_metric_alarm.cpu_high_critical.threshold
+    error_message = "CPU warning threshold must be lower than the critical threshold."
+  }
+}
+
+# ── Test: ALB alarms not created when alb_arn_suffix is null ──────────────────
+
+run "alb_alarms_skipped_without_alb" {
+  command = plan
+
+  variables {
+    name                   = "test-app"
+    environment            = "test"
+    autoscaling_group_name = "test-app-asg"
+    alb_arn_suffix         = null
+    target_group_arn_suffix = null
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.alb_5xx_errors) == 0
+    error_message = "ALB 5xx alarm must not be created when alb_arn_suffix is null."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.alb_unhealthy_hosts) == 0
+    error_message = "Unhealthy hosts alarm must not be created when alb_arn_suffix is null."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.alb_response_time) == 0
+    error_message = "Response time alarm must not be created when alb_arn_suffix is null."
+  }
+}
+
+# ── Test: ALB alarms are created when alb_arn_suffix is provided ──────────────
+
+run "alb_alarms_created_with_alb" {
+  command = plan
+
+  variables {
+    name                    = "test-app"
+    environment             = "test"
+    autoscaling_group_name  = "test-app-asg"
+    alb_arn_suffix          = "app/test-app/abc123"
+    target_group_arn_suffix = "targetgroup/test-app/def456"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.alb_5xx_errors) == 1
+    error_message = "ALB 5xx alarm must be created when alb_arn_suffix is provided."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.alb_unhealthy_hosts) == 1
+    error_message = "Unhealthy hosts alarm must be created when both ALB and target group suffixes are provided."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.alb_response_time) == 1
+    error_message = "Response time alarm must be created when alb_arn_suffix is provided."
+  }
+}

--- a/modules/monitoring/outputs.tf
+++ b/modules/monitoring/outputs.tf
@@ -22,3 +22,23 @@ output "status_check_alarm_arn" {
   description = "ARN of the EC2 status check CloudWatch alarm."
   value       = aws_cloudwatch_metric_alarm.instance_status_check.arn
 }
+
+output "alb_5xx_alarm_arn" {
+  description = "ARN of the ALB 5xx error CloudWatch alarm. Empty string when no ALB is configured."
+  value       = length(aws_cloudwatch_metric_alarm.alb_5xx_errors) > 0 ? aws_cloudwatch_metric_alarm.alb_5xx_errors[0].arn : ""
+}
+
+output "alb_unhealthy_hosts_alarm_arn" {
+  description = "ARN of the ALB unhealthy hosts CloudWatch alarm. Empty string when no ALB/target group is configured."
+  value       = length(aws_cloudwatch_metric_alarm.alb_unhealthy_hosts) > 0 ? aws_cloudwatch_metric_alarm.alb_unhealthy_hosts[0].arn : ""
+}
+
+output "alb_response_time_alarm_arn" {
+  description = "ARN of the ALB p99 response time CloudWatch alarm. Empty string when no ALB is configured."
+  value       = length(aws_cloudwatch_metric_alarm.alb_response_time) > 0 ? aws_cloudwatch_metric_alarm.alb_response_time[0].arn : ""
+}
+
+output "sns_subscription_confirmation_required" {
+  description = "Reminder: if alarm_email was set, the SNS email subscription requires manual confirmation. Check the inbox for the address provided and confirm before alarms become active."
+  value       = var.alarm_email != null ? "ACTION REQUIRED: confirm SNS subscription sent to ${var.alarm_email}" : "no email subscription configured"
+}

--- a/modules/monitoring/outputs.tf
+++ b/modules/monitoring/outputs.tf
@@ -1,0 +1,24 @@
+output "sns_topic_arn" {
+  description = "The ARN of the SNS alarm topic. Use this to add additional subscriptions (e.g. PagerDuty, Slack Lambda)."
+  value       = aws_sns_topic.alarms.arn
+}
+
+output "sns_topic_name" {
+  description = "The name of the SNS alarm topic."
+  value       = aws_sns_topic.alarms.name
+}
+
+output "cpu_warning_alarm_arn" {
+  description = "ARN of the CPU warning CloudWatch alarm."
+  value       = aws_cloudwatch_metric_alarm.cpu_high_warning.arn
+}
+
+output "cpu_critical_alarm_arn" {
+  description = "ARN of the CPU critical CloudWatch alarm."
+  value       = aws_cloudwatch_metric_alarm.cpu_high_critical.arn
+}
+
+output "status_check_alarm_arn" {
+  description = "ARN of the EC2 status check CloudWatch alarm."
+  value       = aws_cloudwatch_metric_alarm.instance_status_check.arn
+}

--- a/modules/monitoring/variables.tf
+++ b/modules/monitoring/variables.tf
@@ -1,0 +1,62 @@
+variable "name" {
+  description = "Name prefix for all monitoring resources (SNS topic, alarms)."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)."
+  type        = string
+}
+
+variable "autoscaling_group_name" {
+  description = "Name of the Auto Scaling Group to monitor. Used as a CloudWatch dimension."
+  type        = string
+}
+
+variable "alarm_email" {
+  description = "Email address to receive alarm notifications. A subscription confirmation email will be sent. Set to null to skip email subscription."
+  type        = string
+  default     = null
+}
+
+variable "cpu_warning_threshold" {
+  description = "CPU utilisation percentage that triggers the warning alarm."
+  type        = number
+  default     = 70
+}
+
+variable "cpu_critical_threshold" {
+  description = "CPU utilisation percentage that triggers the critical alarm."
+  type        = number
+  default     = 90
+}
+
+variable "alb_arn_suffix" {
+  description = "ARN suffix of the Application Load Balancer (from the ALB module's alb_arn_suffix output). ALB alarms are skipped when this is null."
+  type        = string
+  default     = null
+}
+
+variable "target_group_arn_suffix" {
+  description = "ARN suffix of the ALB target group (from the ALB module's target_group_arn_suffix output). Required for the unhealthy host alarm."
+  type        = string
+  default     = null
+}
+
+variable "alb_5xx_threshold" {
+  description = "Number of ALB 5XX responses per minute that triggers the error alarm."
+  type        = number
+  default     = 10
+}
+
+variable "alb_response_time_threshold" {
+  description = "ALB p99 target response time in seconds that triggers the latency alarm."
+  type        = number
+  default     = 3
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all monitoring resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/monitoring/versions.tf
+++ b/modules/monitoring/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/networking/security-group-module/.terraform.lock.hcl
+++ b/modules/networking/security-group-module/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/networking/security-group-module/README.md
+++ b/modules/networking/security-group-module/README.md
@@ -1,0 +1,200 @@
+# modules/networking/security-group-module
+
+Creates an **EC2 Security Group** with fully dynamic ingress and egress rules. Supports both CIDR-based rules and security-group-sourced rules in separate variable lists.
+
+The module uses `create_before_destroy = true` on the security group so that Terraform can replace security groups (e.g. when the name or VPC changes) without first destroying the old one and leaving resources temporarily without a security group.
+
+---
+
+## Usage
+
+### ALB security group (internet-facing)
+
+```hcl
+module "alb_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "my-app-dev-alb"
+  description = "ALB — allow inbound HTTP and HTTPS from the internet"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_rules = [
+    {
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTP from internet"
+    },
+    {
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "HTTPS from internet"
+    }
+  ]
+}
+```
+
+### EC2 application security group (ALB-only ingress)
+
+```hcl
+module "app_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "my-app-dev-ec2"
+  description = "EC2 instances — allow inbound from ALB only"
+  vpc_id      = module.vpc.vpc_id
+
+  # No CIDR-based ingress — instances are not directly accessible
+  ingress_sg_rules = [
+    {
+      from_port                = 8080
+      to_port                  = 8080
+      protocol                 = "tcp"
+      source_security_group_id = module.alb_sg.security_group_id
+      description              = "Application port from ALB"
+    }
+  ]
+}
+```
+
+### Mixed CIDR and SG-source ingress
+
+```hcl
+module "db_sg" {
+  source = "../../modules/networking/security-group-module"
+
+  name        = "my-app-dev-db"
+  description = "Database — allow from app tier and VPN CIDR"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_sg_rules = [
+    {
+      from_port                = 5432
+      to_port                  = 5432
+      protocol                 = "tcp"
+      source_security_group_id = module.app_sg.security_group_id
+      description              = "PostgreSQL from app tier"
+    }
+  ]
+
+  ingress_rules = [
+    {
+      from_port   = 5432
+      to_port     = 5432
+      protocol    = "tcp"
+      cidr_blocks = ["10.100.0.0/16"]   # VPN CIDR
+      description = "PostgreSQL from VPN"
+    }
+  ]
+
+  # Restrict egress to VPC only (override the default allow-all)
+  egress_rules = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["10.0.0.0/8"]
+      description = "All traffic to internal networks only"
+    }
+  ]
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `name` | Name of the security group. Must be unique within the VPC. | `string` | — | yes |
+| `vpc_id` | VPC ID where the security group will be created. | `string` | — | yes |
+| `description` | Description of the security group's purpose. | `string` | `"Managed by Terraform"` | no |
+| `ingress_rules` | CIDR-based ingress rules. Use this for rules where the source is an IP range. | `list(object)` | `[]` | no |
+| `ingress_sg_rules` | Security-group-sourced ingress rules. Use this when the source is another security group. | `list(object)` | `[]` | no |
+| `egress_rules` | CIDR-based egress rules. Defaults to allow-all outbound (common for EC2). Restrict this in high-security environments. | `list(object)` | allow-all | no |
+| `tags` | Additional tags applied to the security group. | `map(string)` | `{}` | no |
+
+### `ingress_rules` object schema
+
+```hcl
+{
+  from_port   = number          # Start of port range (or 0 for all)
+  to_port     = number          # End of port range (or 0 for all)
+  protocol    = string          # "tcp", "udp", "icmp", or "-1" for all
+  cidr_blocks = list(string)    # Source CIDR blocks
+  description = string          # Human-readable description
+}
+```
+
+### `ingress_sg_rules` object schema
+
+```hcl
+{
+  from_port                = number  # Start of port range
+  to_port                  = number  # End of port range
+  protocol                 = string  # "tcp", "udp", "icmp", or "-1"
+  source_security_group_id = string  # ID of the source security group
+  description              = string  # Human-readable description
+}
+```
+
+### `egress_rules` object schema
+
+Same as `ingress_rules`.
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `security_group_id` | The ID of the security group. Pass to `alb` and `compute` modules. |
+| `security_group_arn` | The ARN of the security group. |
+| `security_group_name` | The name of the security group. |
+
+---
+
+## Notes
+
+### CIDR vs SG-source rules
+
+AWS differentiates between CIDR-source and SG-source ingress rules. In the Terraform AWS provider, these cannot be mixed in the same `ingress` block. This module handles the split by providing two separate variables (`ingress_rules` for CIDR-based, `ingress_sg_rules` for SG-sourced), which are rendered as separate `dynamic ingress` blocks in the underlying resource.
+
+### Egress default
+
+The default egress rule allows all outbound traffic (`0.0.0.0/0`, all ports, all protocols). This is the standard for application servers — they need to reach package repositories, AWS APIs, and other services. For databases and other sensitive resources, restrict egress to specific CIDRs and ports.
+
+### Security group chaining
+
+The typical three-tier pattern is:
+
+```
+Internet → [ALB SG] → ALB → [App SG, source=ALB SG] → EC2 → [DB SG, source=App SG] → RDS
+```
+
+This ensures:
+- No direct internet access to EC2 instances or databases.
+- The ALB is the only ingress point.
+- Databases only accept connections from the application tier.
+
+### Naming conventions
+
+Use descriptive names that indicate the resource and environment:
+
+```
+my-app-prod-alb     # ALB security group
+my-app-prod-ec2     # Application EC2 security group
+my-app-prod-db      # Database security group
+```

--- a/modules/networking/security-group-module/main.tf
+++ b/modules/networking/security-group-module/main.tf
@@ -1,1 +1,33 @@
+resource "aws_security_group" "this" {
+  name        = var.name
+  description = var.description
+  vpc_id      = var.vpc_id
 
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = ingress.value.cidr_blocks
+      description = ingress.value.description
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.egress_rules
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = egress.value.cidr_blocks
+      description = egress.value.description
+    }
+  }
+
+  tags = merge({ Name = var.name }, var.tags)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/networking/security-group-module/main.tf
+++ b/modules/networking/security-group-module/main.tf
@@ -38,7 +38,7 @@ resource "aws_security_group" "this" {
     }
   }
 
-  tags = merge({ Name = var.name }, var.tags)
+  tags = merge({ Name = var.name, ManagedBy = "Terraform" }, var.tags)
 
   lifecycle {
     create_before_destroy = true

--- a/modules/networking/security-group-module/main.tf
+++ b/modules/networking/security-group-module/main.tf
@@ -19,11 +19,11 @@ resource "aws_security_group" "this" {
   dynamic "ingress" {
     for_each = var.ingress_sg_rules
     content {
-      from_port                = ingress.value.from_port
-      to_port                  = ingress.value.to_port
-      protocol                 = ingress.value.protocol
-      security_groups          = [ingress.value.source_security_group_id]
-      description              = ingress.value.description
+      from_port       = ingress.value.from_port
+      to_port         = ingress.value.to_port
+      protocol        = ingress.value.protocol
+      security_groups = [ingress.value.source_security_group_id]
+      description     = ingress.value.description
     }
   }
 

--- a/modules/networking/security-group-module/main.tf
+++ b/modules/networking/security-group-module/main.tf
@@ -3,6 +3,7 @@ resource "aws_security_group" "this" {
   description = var.description
   vpc_id      = var.vpc_id
 
+  # CIDR-based ingress rules (e.g. allow traffic from a known IP range)
   dynamic "ingress" {
     for_each = var.ingress_rules
     content {
@@ -11,6 +12,18 @@ resource "aws_security_group" "this" {
       protocol    = ingress.value.protocol
       cidr_blocks = ingress.value.cidr_blocks
       description = ingress.value.description
+    }
+  }
+
+  # Security-group-source ingress rules (e.g. allow traffic from an ALB SG)
+  dynamic "ingress" {
+    for_each = var.ingress_sg_rules
+    content {
+      from_port                = ingress.value.from_port
+      to_port                  = ingress.value.to_port
+      protocol                 = ingress.value.protocol
+      security_groups          = [ingress.value.source_security_group_id]
+      description              = ingress.value.description
     }
   }
 

--- a/modules/networking/security-group-module/outputs.tf
+++ b/modules/networking/security-group-module/outputs.tf
@@ -1,0 +1,14 @@
+output "security_group_id" {
+  description = "The ID of the security group"
+  value       = aws_security_group.this.id
+}
+
+output "security_group_arn" {
+  description = "The ARN of the security group"
+  value       = aws_security_group.this.arn
+}
+
+output "security_group_name" {
+  description = "The name of the security group"
+  value       = aws_security_group.this.name
+}

--- a/modules/networking/security-group-module/sg_unit.tftest.hcl
+++ b/modules/networking/security-group-module/sg_unit.tftest.hcl
@@ -1,0 +1,135 @@
+# Unit tests for modules/networking/security-group-module
+# Run with: terraform -chdir=modules/networking/security-group-module test
+
+mock_provider "aws" {}
+
+# ── Test: SG name matches variable ────────────────────────────────────────────
+
+run "name_is_set" {
+  command = plan
+
+  variables {
+    name   = "test-sg"
+    vpc_id = "vpc-12345678"
+  }
+
+  assert {
+    condition     = aws_security_group.this.name == "test-sg"
+    error_message = "Security group name must match the name variable."
+  }
+}
+
+# ── Test: ManagedBy tag is always applied ─────────────────────────────────────
+
+run "managed_by_tag_always_present" {
+  command = plan
+
+  variables {
+    name   = "test-sg"
+    vpc_id = "vpc-12345678"
+  }
+
+  assert {
+    condition     = aws_security_group.this.tags["ManagedBy"] == "Terraform"
+    error_message = "ManagedBy=Terraform tag must always be applied."
+  }
+}
+
+# ── Test: no ingress rules by default ─────────────────────────────────────────
+
+run "no_ingress_rules_by_default" {
+  command = plan
+
+  variables {
+    name   = "test-sg"
+    vpc_id = "vpc-12345678"
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.ingress) == 0
+    error_message = "No ingress rules should be created when ingress_rules and ingress_sg_rules are empty."
+  }
+}
+
+# ── Test: default egress allows all outbound ──────────────────────────────────
+
+run "default_egress_allows_all" {
+  command = plan
+
+  variables {
+    name   = "test-sg"
+    vpc_id = "vpc-12345678"
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.egress) == 1
+    error_message = "Default egress rules should create exactly one rule."
+  }
+
+  assert {
+    condition     = tolist(aws_security_group.this.egress)[0].protocol == "-1"
+    error_message = "Default egress rule must use protocol -1 (all traffic)."
+  }
+
+  assert {
+    condition     = contains(tolist(aws_security_group.this.egress)[0].cidr_blocks, "0.0.0.0/0")
+    error_message = "Default egress rule must allow 0.0.0.0/0."
+  }
+}
+
+# ── Test: CIDR-based ingress rules are counted correctly ──────────────────────
+
+run "ingress_cidr_rules_counted" {
+  command = plan
+
+  variables {
+    name   = "test-sg"
+    vpc_id = "vpc-12345678"
+    ingress_rules = [
+      {
+        from_port   = 80
+        to_port     = 80
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow HTTP"
+      },
+      {
+        from_port   = 443
+        to_port     = 443
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow HTTPS"
+      },
+    ]
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.ingress) == 2
+    error_message = "One ingress rule must be created per entry in ingress_rules."
+  }
+}
+
+# ── Test: SG-source ingress rules are counted correctly ───────────────────────
+
+run "ingress_sg_rules_counted" {
+  command = plan
+
+  variables {
+    name   = "test-sg"
+    vpc_id = "vpc-12345678"
+    ingress_sg_rules = [
+      {
+        from_port                = 8080
+        to_port                  = 8080
+        protocol                 = "tcp"
+        source_security_group_id = "sg-aabbccdd"
+        description              = "Allow traffic from ALB"
+      },
+    ]
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.ingress) == 1
+    error_message = "One ingress rule must be created per entry in ingress_sg_rules."
+  }
+}

--- a/modules/networking/security-group-module/sg_unit.tftest.hcl
+++ b/modules/networking/security-group-module/sg_unit.tftest.hcl
@@ -38,7 +38,7 @@ run "managed_by_tag_always_present" {
 # ── Test: no ingress rules by default ─────────────────────────────────────────
 
 run "no_ingress_rules_by_default" {
-  command = plan
+  command = apply
 
   variables {
     name   = "test-sg"
@@ -54,7 +54,7 @@ run "no_ingress_rules_by_default" {
 # ── Test: default egress allows all outbound ──────────────────────────────────
 
 run "default_egress_allows_all" {
-  command = plan
+  command = apply
 
   variables {
     name   = "test-sg"
@@ -80,7 +80,7 @@ run "default_egress_allows_all" {
 # ── Test: CIDR-based ingress rules are counted correctly ──────────────────────
 
 run "ingress_cidr_rules_counted" {
-  command = plan
+  command = apply
 
   variables {
     name   = "test-sg"
@@ -112,7 +112,7 @@ run "ingress_cidr_rules_counted" {
 # ── Test: SG-source ingress rules are counted correctly ───────────────────────
 
 run "ingress_sg_rules_counted" {
-  command = plan
+  command = apply
 
   variables {
     name   = "test-sg"

--- a/modules/networking/security-group-module/variables.tf
+++ b/modules/networking/security-group-module/variables.tf
@@ -15,7 +15,7 @@ variable "vpc_id" {
 }
 
 variable "ingress_rules" {
-  description = "List of ingress rules"
+  description = "CIDR-based ingress rules. Use ingress_sg_rules to reference other security groups."
   type = list(object({
     from_port   = number
     to_port     = number
@@ -26,8 +26,20 @@ variable "ingress_rules" {
   default = []
 }
 
+variable "ingress_sg_rules" {
+  description = "Security-group-source ingress rules. Use this instead of ingress_rules when the source is another SG."
+  type = list(object({
+    from_port                = number
+    to_port                  = number
+    protocol                 = string
+    source_security_group_id = string
+    description              = string
+  }))
+  default = []
+}
+
 variable "egress_rules" {
-  description = "List of egress rules"
+  description = "CIDR-based egress rules. Default allows all outbound — restrict this in production."
   type = list(object({
     from_port   = number
     to_port     = number

--- a/modules/networking/security-group-module/variables.tf
+++ b/modules/networking/security-group-module/variables.tf
@@ -1,0 +1,53 @@
+variable "name" {
+  description = "Name of the security group"
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the security group"
+  type        = string
+  default     = "Managed by Terraform"
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the security group will be created"
+  type        = string
+}
+
+variable "ingress_rules" {
+  description = "List of ingress rules"
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+    description = string
+  }))
+  default = []
+}
+
+variable "egress_rules" {
+  description = "List of egress rules"
+  type = list(object({
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = list(string)
+    description = string
+  }))
+  default = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+      description = "Allow all outbound traffic"
+    }
+  ]
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the security group"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/networking/security-group-module/versions.tf
+++ b/modules/networking/security-group-module/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/networking/vpc-endpoint-module/.terraform.lock.hcl
+++ b/modules/networking/vpc-endpoint-module/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/networking/vpc-endpoint-module/main.tf
+++ b/modules/networking/vpc-endpoint-module/main.tf
@@ -3,10 +3,19 @@ resource "aws_vpc_endpoint" "this" {
   service_name      = var.service_name
   vpc_endpoint_type = var.endpoint_type
 
-  security_group_ids = var.security_group_ids
+  # security_group_ids and subnet_ids are only valid for Interface endpoints.
+  # Gateway endpoints (e.g. S3, DynamoDB) use route table associations instead.
+  security_group_ids = var.endpoint_type == "Interface" ? var.security_group_ids : []
   subnet_ids         = var.endpoint_type == "Interface" ? var.subnet_ids : []
 
-  tags = {
-    Name = "VPC Endpoint for ${var.service_name}"
-  }
+  # For Gateway endpoints, associate with the supplied route tables.
+  route_table_ids = var.endpoint_type == "Gateway" ? var.route_table_ids : []
+
+  tags = merge(
+    {
+      Name      = "vpc-endpoint-${var.service_name}"
+      ManagedBy = "Terraform"
+    },
+    var.tags
+  )
 }

--- a/modules/networking/vpc-endpoint-module/variables.tf
+++ b/modules/networking/vpc-endpoint-module/variables.tf
@@ -4,25 +4,41 @@ variable "vpc_id" {
 }
 
 variable "service_name" {
-  description = "The service name for the VPC endpoint."
+  description = "The AWS service name for the VPC endpoint (e.g. com.amazonaws.us-west-2.s3)."
   type        = string
 }
 
 variable "endpoint_type" {
-  description = "The type of endpoint: Interface or Gateway."
-  default     = "Interface"
+  description = "The type of endpoint. Must be 'Interface' or 'Gateway'."
   type        = string
+  default     = "Interface"
+
+  validation {
+    condition     = contains(["Interface", "Gateway"], var.endpoint_type)
+    error_message = "endpoint_type must be 'Interface' or 'Gateway'."
+  }
 }
 
 variable "security_group_ids" {
-  description = "List of security group IDs to be associated with the endpoint."
+  description = "Security group IDs for the endpoint. Only applies to Interface endpoints."
   type        = list(string)
   default     = []
 }
 
 variable "subnet_ids" {
-  description = "List of subnet IDs for the endpoint. Required for Interface type."
+  description = "Subnet IDs for the endpoint. Required for Interface endpoints."
   type        = list(string)
   default     = []
 }
 
+variable "route_table_ids" {
+  description = "Route table IDs to associate with the endpoint. Required for Gateway endpoints."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the endpoint."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/networking/vpc-endpoint-module/versions.tf
+++ b/modules/networking/vpc-endpoint-module/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/networking/vpc-endpoint-module/vpc_endpoint_unit.tftest.hcl
+++ b/modules/networking/vpc-endpoint-module/vpc_endpoint_unit.tftest.hcl
@@ -1,0 +1,101 @@
+# Unit tests for modules/networking/vpc-endpoint-module
+# Run with: terraform -chdir=modules/networking/vpc-endpoint-module test
+
+mock_provider "aws" {}
+
+# ── Test: Interface endpoint wires security groups and subnets ────────────────
+
+run "interface_endpoint_uses_sg_and_subnets" {
+  command = plan
+
+  variables {
+    vpc_id        = "vpc-12345678"
+    service_name  = "com.amazonaws.us-west-2.ssm"
+    endpoint_type = "Interface"
+    security_group_ids = ["sg-11111111"]
+    subnet_ids         = ["subnet-aaaaaaaa", "subnet-bbbbbbbb"]
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.this.vpc_endpoint_type == "Interface"
+    error_message = "Endpoint type must be Interface."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.this.security_group_ids) == 1
+    error_message = "Interface endpoint must attach the supplied security group IDs."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.this.subnet_ids) == 2
+    error_message = "Interface endpoint must attach the supplied subnet IDs."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.this.route_table_ids) == 0
+    error_message = "Interface endpoint must not have route_table_ids."
+  }
+}
+
+# ── Test: Gateway endpoint wires route tables, not SGs or subnets ─────────────
+
+run "gateway_endpoint_uses_route_tables" {
+  command = plan
+
+  variables {
+    vpc_id          = "vpc-12345678"
+    service_name    = "com.amazonaws.us-west-2.s3"
+    endpoint_type   = "Gateway"
+    route_table_ids = ["rtb-11111111", "rtb-22222222"]
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.this.vpc_endpoint_type == "Gateway"
+    error_message = "Endpoint type must be Gateway."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.this.route_table_ids) == 2
+    error_message = "Gateway endpoint must attach the supplied route table IDs."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.this.security_group_ids) == 0
+    error_message = "Gateway endpoint must not have security_group_ids."
+  }
+
+  assert {
+    condition     = length(aws_vpc_endpoint.this.subnet_ids) == 0
+    error_message = "Gateway endpoint must not have subnet_ids."
+  }
+}
+
+# ── Test: invalid endpoint_type is rejected ───────────────────────────────────
+
+run "rejects_invalid_endpoint_type" {
+  command = plan
+
+  variables {
+    vpc_id        = "vpc-12345678"
+    service_name  = "com.amazonaws.us-west-2.s3"
+    endpoint_type = "GatewayLoadBalancer"
+  }
+
+  expect_failures = [var.endpoint_type]
+}
+
+# ── Test: ManagedBy tag is always applied ─────────────────────────────────────
+
+run "managed_by_tag_always_present" {
+  command = plan
+
+  variables {
+    vpc_id       = "vpc-12345678"
+    service_name = "com.amazonaws.us-west-2.ssm"
+  }
+
+  assert {
+    condition     = aws_vpc_endpoint.this.tags["ManagedBy"] == "Terraform"
+    error_message = "ManagedBy=Terraform tag must always be applied."
+  }
+}

--- a/modules/networking/vpc-endpoint-module/vpc_endpoint_unit.tftest.hcl
+++ b/modules/networking/vpc-endpoint-module/vpc_endpoint_unit.tftest.hcl
@@ -9,9 +9,9 @@ run "interface_endpoint_uses_sg_and_subnets" {
   command = plan
 
   variables {
-    vpc_id        = "vpc-12345678"
-    service_name  = "com.amazonaws.us-west-2.ssm"
-    endpoint_type = "Interface"
+    vpc_id             = "vpc-12345678"
+    service_name       = "com.amazonaws.us-west-2.ssm"
+    endpoint_type      = "Interface"
     security_group_ids = ["sg-11111111"]
     subnet_ids         = ["subnet-aaaaaaaa", "subnet-bbbbbbbb"]
   }

--- a/modules/networking/vpc-module/.terraform.lock.hcl
+++ b/modules/networking/vpc-module/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/networking/vpc-module/README.md
+++ b/modules/networking/vpc-module/README.md
@@ -1,0 +1,155 @@
+# modules/networking/vpc-module
+
+Creates a **Virtual Private Cloud** with public and private subnets across multiple availability zones, Internet Gateway, NAT Gateways, route tables, and optional VPC Flow Logs.
+
+Key design decisions:
+- **Public subnets** map public IPs on launch and route to the Internet Gateway — intended for load balancers and NAT Gateways only.
+- **Private subnets** have no public IP assignment and route to NAT Gateways — intended for application EC2 instances and data stores.
+- **NAT Gateway mode** is configurable: a single shared NAT Gateway reduces cost but is a single point of failure; one NAT Gateway per AZ provides full high availability.
+- **VPC Flow Logs** capture all `ACCEPT` and `REJECT` traffic metadata to CloudWatch Logs. Enabled by default. This is a CIS AWS Foundations Benchmark requirement.
+
+---
+
+## Usage
+
+### Development (single NAT Gateway, 2 AZs)
+
+```hcl
+module "vpc" {
+  source = "../../modules/networking/vpc-module"
+
+  environment = "dev"
+  vpc_cidr    = "10.0.0.0/16"
+  azs         = ["us-west-2a", "us-west-2b"]
+
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true   # cost-optimised; not HA
+}
+```
+
+### Production (one NAT Gateway per AZ, 3 AZs)
+
+```hcl
+module "vpc" {
+  source = "../../modules/networking/vpc-module"
+
+  environment = "prod"
+  vpc_cidr    = "10.2.0.0/16"
+  azs         = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+  public_subnet_cidrs = [
+    "10.2.1.0/24",
+    "10.2.2.0/24",
+    "10.2.3.0/24",
+  ]
+  private_subnet_cidrs = [
+    "10.2.11.0/24",
+    "10.2.12.0/24",
+    "10.2.13.0/24",
+  ]
+
+  enable_nat_gateway       = true
+  single_nat_gateway       = false   # one NAT GW per AZ for full HA
+  enable_flow_logs         = true
+  flow_logs_retention_days = 90
+}
+```
+
+### Passing subnet IDs to other modules
+
+```hcl
+module "alb" {
+  source     = "../../modules/alb"
+  subnet_ids = module.vpc.public_subnet_ids    # ALB lives in public subnets
+  vpc_id     = module.vpc.vpc_id
+  # ...
+}
+
+module "compute" {
+  source     = "../../modules/compute"
+  subnet_ids = module.vpc.private_subnet_ids   # EC2 lives in private subnets
+  # ...
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `environment` | Environment name (e.g. dev, staging, prod). Used in resource names and tags. | `string` | — | yes |
+| `azs` | List of availability zone names. Must have at least two for HA. The number of AZs determines subnet count. | `list(string)` | — | yes |
+| `vpc_cidr` | CIDR block for the VPC. | `string` | `"10.0.0.0/16"` | no |
+| `public_subnet_cidrs` | CIDR blocks for public subnets. One per AZ. Must be within `vpc_cidr`. | `list(string)` | `[]` | no |
+| `private_subnet_cidrs` | CIDR blocks for private subnets. One per AZ. Must be within `vpc_cidr`. | `list(string)` | `[]` | no |
+| `enable_nat_gateway` | Create NAT Gateway(s) for private subnet egress. Set to `false` to remove internet access from private subnets (e.g. fully air-gapped environments using VPC endpoints). | `bool` | `true` | no |
+| `single_nat_gateway` | Use a single NAT Gateway shared across all private subnets instead of one per AZ. Reduces cost but removes AZ-level HA for egress traffic. | `bool` | `false` | no |
+| `enable_dns_hostnames` | Enable DNS hostnames in the VPC. Required for some services (e.g. ECS, EFS). | `bool` | `true` | no |
+| `enable_dns_support` | Enable DNS resolution in the VPC. | `bool` | `true` | no |
+| `enable_flow_logs` | Capture VPC traffic metadata in CloudWatch Logs. Recommended for all environments. | `bool` | `true` | no |
+| `flow_logs_retention_days` | Number of days to retain VPC Flow Log entries in CloudWatch Logs. | `number` | `30` | no |
+| `tags` | Additional tags applied to all resources. | `map(string)` | `{}` | no |
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `vpc_id` | The ID of the VPC. |
+| `vpc_cidr` | The CIDR block of the VPC. |
+| `public_subnet_ids` | List of public subnet IDs (one per AZ). Pass to the ALB module. |
+| `private_subnet_ids` | List of private subnet IDs (one per AZ). Pass to the compute module. |
+| `nat_gateway_ids` | List of NAT Gateway IDs. |
+| `internet_gateway_id` | The ID of the Internet Gateway. |
+| `public_route_table_id` | The ID of the shared public route table. |
+| `private_route_table_ids` | List of private route table IDs (one per AZ when NAT is enabled). |
+| `flow_log_group_name` | CloudWatch Log Group name for VPC Flow Logs. Empty string when flow logs are disabled. |
+
+---
+
+## Notes
+
+### Subnet sizing
+
+Each subnet's CIDR should be sized to accommodate your maximum number of resources per AZ, plus AWS's 5-address reservation per subnet. A `/24` gives 251 usable addresses, which is sufficient for most workloads. Use `/22` (1019 addresses) for large deployments.
+
+### NAT Gateway cost
+
+NAT Gateway charges include:
+- An hourly rate per NAT Gateway (~$0.045/hour in us-east-1)
+- A per-GB data processing charge (~$0.045/GB in us-east-1)
+
+For development environments with `single_nat_gateway = true`, one NAT Gateway is sufficient. For production with `single_nat_gateway = false` and 3 AZs, three NAT Gateways are created — this triples the hourly cost but eliminates cross-AZ failure dependency.
+
+### VPC Flow Logs
+
+Flow Logs record metadata (source IP, destination IP, port, protocol, bytes, action) for all traffic in and out of the VPC. They do **not** capture the packet payload. This data is useful for:
+- Security incident investigation
+- Network troubleshooting
+- Compliance (CIS AWS Benchmark control 3.9)
+
+The IAM role and policy for flow logs are created by this module — no external setup required.
+
+### CIDR planning
+
+Avoid overlapping CIDRs between environments if you plan to use VPC peering or AWS Transit Gateway in future. A common allocation strategy:
+
+| Environment | VPC CIDR |
+|-------------|----------|
+| dev | `10.0.0.0/16` |
+| staging | `10.1.0.0/16` |
+| prod | `10.2.0.0/16` |

--- a/modules/networking/vpc-module/main.tf
+++ b/modules/networking/vpc-module/main.tf
@@ -167,7 +167,10 @@ resource "aws_iam_role_policy" "flow_logs" {
         "logs:DescribeLogGroups",
         "logs:DescribeLogStreams",
       ]
-      Resource = "*"
+      Resource = [
+        aws_cloudwatch_log_group.flow_logs[0].arn,
+        "${aws_cloudwatch_log_group.flow_logs[0].arn}:*",
+      ]
     }]
   })
 }

--- a/modules/networking/vpc-module/main.tf
+++ b/modules/networking/vpc-module/main.tf
@@ -1,0 +1,121 @@
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+
+  nat_gateway_count = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_dns_support   = var.enable_dns_support
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-vpc"
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-public-subnet-${count.index + 1}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.azs[count.index]
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-private-subnet-${count.index + 1}"
+    Tier = "private"
+  })
+}
+
+resource "aws_eip" "nat" {
+  count  = local.nat_gateway_count
+  domain = "vpc"
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-nat-eip-${count.index + 1}"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_nat_gateway" "this" {
+  count = local.nat_gateway_count
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-nat-gw-${count.index + 1}"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-public-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count  = local.nat_gateway_count > 0 ? length(var.private_subnet_cidrs) : 0
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = var.single_nat_gateway ? aws_nat_gateway.this[0].id : aws_nat_gateway.this[count.index].id
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-private-rt-${count.index + 1}"
+  })
+}
+
+resource "aws_route_table_association" "private" {
+  count = local.nat_gateway_count > 0 ? length(var.private_subnet_cidrs) : 0
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}

--- a/modules/networking/vpc-module/main.tf
+++ b/modules/networking/vpc-module/main.tf
@@ -119,3 +119,68 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private[count.index].id
 }
+
+# ── VPC Flow Logs ─────────────────────────────────────────────────────────────
+# Flow logs capture IP traffic metadata for security auditing and troubleshooting.
+# They are a CIS AWS Foundations Benchmark requirement.
+
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name              = "/aws/vpc/flow-logs/${var.environment}"
+  retention_in_days = var.flow_logs_retention_days
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.environment}-vpc-flow-logs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.environment}-vpc-flow-logs-policy"
+  role = aws_iam_role.flow_logs[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_flow_log" "this" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  vpc_id          = aws_vpc.this.id
+  traffic_type    = "ALL"
+  iam_role_arn    = aws_iam_role.flow_logs[0].arn
+  log_destination = aws_cloudwatch_log_group.flow_logs[0].arn
+
+  tags = merge(local.common_tags, {
+    Name = "${var.environment}-vpc-flow-logs"
+  })
+}

--- a/modules/networking/vpc-module/outputs.tf
+++ b/modules/networking/vpc-module/outputs.tf
@@ -32,3 +32,13 @@ output "public_route_table_id" {
   description = "The ID of the public route table"
   value       = aws_route_table.public.id
 }
+
+output "private_route_table_ids" {
+  description = "List of IDs of the private route tables (one per AZ when NAT GW enabled)"
+  value       = aws_route_table.private[*].id
+}
+
+output "flow_log_group_name" {
+  description = "CloudWatch Log Group name for VPC Flow Logs (empty string if disabled)"
+  value       = var.enable_flow_logs ? aws_cloudwatch_log_group.flow_logs[0].name : ""
+}

--- a/modules/networking/vpc-module/outputs.tf
+++ b/modules/networking/vpc-module/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "List of IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of IDs of the private subnets"
+  value       = aws_subnet.private[*].id
+}
+
+output "nat_gateway_ids" {
+  description = "List of NAT Gateway IDs"
+  value       = aws_nat_gateway.this[*].id
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.this.id
+}
+
+output "public_route_table_id" {
+  description = "The ID of the public route table"
+  value       = aws_route_table.public.id
+}

--- a/modules/networking/vpc-module/variables.tf
+++ b/modules/networking/vpc-module/variables.tf
@@ -1,0 +1,57 @@
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "azs" {
+  description = "List of availability zones to deploy into"
+  type        = list(string)
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets (one per AZ)"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets (one per AZ)"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_nat_gateway" {
+  description = "Whether to create NAT gateway(s) for private subnet egress"
+  type        = bool
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT gateway instead of one per AZ (reduces cost, loses HA)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_dns_hostnames" {
+  description = "Enable DNS hostnames in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Enable DNS resolution support in the VPC"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/networking/vpc-module/variables.tf
+++ b/modules/networking/vpc-module/variables.tf
@@ -50,6 +50,18 @@ variable "enable_dns_support" {
   default     = true
 }
 
+variable "enable_flow_logs" {
+  description = "Enable VPC Flow Logs to CloudWatch Logs (recommended for all environments)"
+  type        = bool
+  default     = true
+}
+
+variable "flow_logs_retention_days" {
+  description = "Number of days to retain VPC Flow Log entries in CloudWatch"
+  type        = number
+  default     = 30
+}
+
 variable "tags" {
   description = "Additional tags to apply to all resources"
   type        = map(string)

--- a/modules/networking/vpc-module/versions.tf
+++ b/modules/networking/vpc-module/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/networking/vpc-module/vpc_unit.tftest.hcl
+++ b/modules/networking/vpc-module/vpc_unit.tftest.hcl
@@ -1,0 +1,164 @@
+# Unit tests for modules/networking/vpc-module
+# Run with: terraform -chdir=modules/networking/vpc-module test
+
+mock_provider "aws" {}
+
+# ── Test: DNS settings ────────────────────────────────────────────────────────
+
+run "dns_enabled_by_default" {
+  command = plan
+
+  variables {
+    environment          = "test"
+    azs                  = ["us-west-2a", "us-west-2b"]
+    public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+    private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+  }
+
+  assert {
+    condition     = aws_vpc.this.enable_dns_hostnames == true
+    error_message = "DNS hostnames must be enabled by default."
+  }
+
+  assert {
+    condition     = aws_vpc.this.enable_dns_support == true
+    error_message = "DNS support must be enabled by default."
+  }
+}
+
+# ── Test: subnet count matches AZ count ──────────────────────────────────────
+
+run "creates_correct_subnet_count" {
+  command = plan
+
+  variables {
+    environment          = "test"
+    azs                  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+    public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+    private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+  }
+
+  assert {
+    condition     = length(aws_subnet.public) == 3
+    error_message = "Number of public subnets must match number of AZs."
+  }
+
+  assert {
+    condition     = length(aws_subnet.private) == 3
+    error_message = "Number of private subnets must match number of AZs."
+  }
+}
+
+# ── Test: single NAT gateway mode ─────────────────────────────────────────────
+
+run "single_nat_gateway_creates_one_gateway" {
+  command = plan
+
+  variables {
+    environment          = "dev"
+    azs                  = ["us-west-2a", "us-west-2b"]
+    public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+    private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+    enable_nat_gateway   = true
+    single_nat_gateway   = true
+  }
+
+  assert {
+    condition     = length(aws_nat_gateway.this) == 1
+    error_message = "single_nat_gateway = true must create exactly one NAT gateway."
+  }
+
+  assert {
+    condition     = length(aws_eip.nat) == 1
+    error_message = "single_nat_gateway = true must create exactly one Elastic IP."
+  }
+}
+
+# ── Test: HA NAT gateway mode ─────────────────────────────────────────────────
+
+run "ha_nat_gateway_creates_one_per_az" {
+  command = plan
+
+  variables {
+    environment          = "prod"
+    azs                  = ["us-west-2a", "us-west-2b", "us-west-2c"]
+    public_subnet_cidrs  = ["10.2.1.0/24", "10.2.2.0/24", "10.2.3.0/24"]
+    private_subnet_cidrs = ["10.2.11.0/24", "10.2.12.0/24", "10.2.13.0/24"]
+    enable_nat_gateway   = true
+    single_nat_gateway   = false
+  }
+
+  assert {
+    condition     = length(aws_nat_gateway.this) == 3
+    error_message = "HA mode must create one NAT gateway per AZ (3 AZs = 3 gateways)."
+  }
+}
+
+# ── Test: no NAT gateway when disabled ───────────────────────────────────────
+
+run "no_nat_gateway_when_disabled" {
+  command = plan
+
+  variables {
+    environment          = "test"
+    azs                  = ["us-west-2a", "us-west-2b"]
+    public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+    private_subnet_cidrs = ["10.0.11.0/24", "10.0.12.0/24"]
+    enable_nat_gateway   = false
+  }
+
+  assert {
+    condition     = length(aws_nat_gateway.this) == 0
+    error_message = "No NAT gateways should be created when enable_nat_gateway = false."
+  }
+}
+
+# ── Test: public subnets map public IPs ───────────────────────────────────────
+
+run "public_subnets_assign_public_ips" {
+  command = plan
+
+  variables {
+    environment         = "test"
+    azs                 = ["us-west-2a"]
+    public_subnet_cidrs = ["10.0.1.0/24"]
+  }
+
+  assert {
+    condition     = aws_subnet.public[0].map_public_ip_on_launch == true
+    error_message = "Public subnets must map public IPs on launch."
+  }
+}
+
+# ── Test: flow logs default ───────────────────────────────────────────────────
+
+run "flow_logs_enabled_by_default" {
+  command = plan
+
+  variables {
+    environment         = "test"
+    azs                 = ["us-west-2a"]
+    public_subnet_cidrs = ["10.0.1.0/24"]
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_group.flow_logs) == 1
+    error_message = "VPC flow logs should be enabled by default."
+  }
+}
+
+run "flow_logs_can_be_disabled" {
+  command = plan
+
+  variables {
+    environment         = "test"
+    azs                 = ["us-west-2a"]
+    public_subnet_cidrs = ["10.0.1.0/24"]
+    enable_flow_logs    = false
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_log_group.flow_logs) == 0
+    error_message = "Flow logs log group should not be created when disabled."
+  }
+}

--- a/modules/storage/.terraform.lock.hcl
+++ b/modules/storage/.terraform.lock.hcl
@@ -1,0 +1,27 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -1,0 +1,165 @@
+# modules/storage
+
+Creates a secure **S3 bucket** with encryption, versioning, lifecycle management, public access blocking, an HTTPS-only bucket policy, and optional server access logging.
+
+Security controls enabled by default:
+- **Public access block** — all four public access block settings are enabled, preventing any object from ever being made public (even with an explicit ACL or bucket policy).
+- **HTTPS-only policy** — a `DenyNonTLSRequests` bucket policy statement denies all requests that do not use TLS (`aws:SecureTransport = false`).
+- **KMS server-side encryption** — objects are encrypted with a customer-managed KMS key (or the AWS-managed `aws/s3` key when no CMK is provided).
+- **Bucket key** — `bucket_key_enabled = true` reduces KMS API calls by ~99% for high-throughput workloads by caching a short-lived bucket key in S3.
+
+---
+
+## Usage
+
+### Minimal (development)
+
+```hcl
+module "storage" {
+  source = "../../modules/storage"
+
+  bucket_name = "my-org-my-app-dev-data"
+  environment = "dev"
+}
+```
+
+### With KMS, lifecycle rules, and logging (production)
+
+```hcl
+module "storage" {
+  source = "../../modules/storage"
+
+  bucket_name        = "my-org-my-app-prod-data"
+  environment        = "prod"
+  kms_key_arn        = module.kms.key_arn
+  versioning_enabled = true
+  force_destroy      = false
+  logging_bucket_id  = aws_s3_bucket.access_logs.id
+
+  lifecycle_rules = [
+    {
+      id      = "transition-to-ia"
+      enabled = true
+
+      expiration_days                    = null
+      noncurrent_version_expiration_days = 90
+
+      transition = [
+        {
+          days          = 30
+          storage_class = "STANDARD_IA"
+        },
+        {
+          days          = 90
+          storage_class = "GLACIER"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Referencing the bucket in other resources
+
+```hcl
+resource "aws_s3_object" "config" {
+  bucket = module.storage.bucket_id
+  key    = "config/app.json"
+  source = "app.json"
+
+  # Objects inherit the bucket's KMS key from the default encryption configuration
+}
+```
+
+---
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | ~> 5.0 |
+
+---
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `bucket_name` | Name of the S3 bucket. Must be globally unique across all AWS accounts and regions. | `string` | — | yes |
+| `environment` | Environment name (e.g. dev, staging, prod). | `string` | — | yes |
+| `versioning_enabled` | Enable object versioning. Required to enable MFA delete. Recommended for buckets containing important data. | `bool` | `true` | no |
+| `force_destroy` | Allow the bucket to be destroyed even when it contains objects. Set to `false` in production to prevent accidental data loss. | `bool` | `false` | no |
+| `kms_key_arn` | ARN of the customer-managed KMS key for server-side encryption. When `null`, uses the AWS-managed `aws/s3` key. | `string` | `null` | no |
+| `logging_bucket_id` | ID (name) of an S3 bucket to receive server access logs. When set, all requests to this bucket are logged with a prefix matching the bucket name. | `string` | `null` | no |
+| `lifecycle_rules` | List of lifecycle rule objects. See the type definition below. | `list(object)` | `[]` | no |
+| `tags` | Additional tags applied to the bucket. | `map(string)` | `{}` | no |
+
+### `lifecycle_rules` type definition
+
+```hcl
+list(object({
+  id                                 = string           # Unique rule identifier
+  enabled                            = bool             # true to activate the rule
+  expiration_days                    = optional(number) # Days until object is deleted
+  noncurrent_version_expiration_days = optional(number) # Days until old version is deleted
+  transition = optional(list(object({
+    days          = number  # Days until transition
+    storage_class = string  # STANDARD_IA, ONEZONE_IA, GLACIER, DEEP_ARCHIVE, etc.
+  })))
+}))
+```
+
+---
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `bucket_id` | The name (ID) of the S3 bucket. |
+| `bucket_arn` | The ARN of the S3 bucket. Use in IAM policies and KMS key policies. |
+| `bucket_domain_name` | The bucket domain name (global, path-style). |
+| `bucket_regional_domain_name` | The regional domain name. Use this for applications within the same region for lower latency. |
+
+---
+
+## Notes
+
+### Bucket naming
+
+S3 bucket names must be globally unique, 3–63 characters, lowercase, and contain only letters, numbers, and hyphens. A good naming convention is:
+
+```
+<org>-<app>-<environment>-<purpose>
+my-org-my-app-prod-data
+my-org-my-app-prod-access-logs
+```
+
+### Bucket key
+
+`bucket_key_enabled = true` is set on the encryption configuration. This generates a short-lived data key in S3 and uses it to encrypt multiple objects, rather than calling KMS for every PUT. For buckets with high object throughput, this significantly reduces KMS API costs and request rates.
+
+### Access logging bucket
+
+The access logging bucket (`logging_bucket_id`) must already exist before this module is applied. It should be a separate bucket — pointing a bucket's logs to itself causes a recursive loop that fills the bucket. The logging bucket should have its own lifecycle rules to expire old logs.
+
+### Lifecycle and versioning ordering
+
+The `aws_s3_bucket_lifecycle_configuration` resource has a `depends_on` relationship with `aws_s3_bucket_versioning`. If you modify versioning and lifecycle in the same apply, Terraform applies versioning first. This prevents the `NoSuchLifecycleConfiguration` error that occurs when lifecycle rules reference versioning behaviour before versioning is enabled.
+
+### KMS key permissions
+
+The IAM principals that read/write to this bucket must have:
+- `kms:GenerateDataKey` — for writing objects
+- `kms:Decrypt` — for reading objects
+
+These permissions should be granted via inline policies in the `iam` module, not via the KMS key policy directly.
+
+### CIS AWS Benchmark coverage
+
+| CIS Control | Implementation |
+|-------------|---------------|
+| 2.1.1 — Server-side encryption | KMS encryption on all objects |
+| 2.1.2 — Public access | All four block settings enabled |
+| 2.1.5 — TLS required | `DenyNonTLSRequests` bucket policy |
+| 3.7 — S3 access logging | Enabled via `logging_bucket_id` |

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -79,3 +79,32 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
   depends_on = [aws_s3_bucket_versioning.this]
 }
+
+# Deny all requests that do not use TLS. This prevents data from being
+# transmitted over unencrypted HTTP, regardless of IAM permissions.
+resource "aws_s3_bucket_policy" "https_only" {
+  bucket = aws_s3_bucket.this.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyNonTLSRequests"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.this.arn,
+          "${aws_s3_bucket.this.arn}/*",
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.this]
+}

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -23,14 +23,20 @@ resource "aws_s3_bucket_versioning" "this" {
   }
 }
 
+# Server-side encryption with a customer-managed KMS key (CMK).
+# Using a CMK instead of the default aws:kms key gives you:
+#   - Full key usage audit trail in CloudTrail
+#   - Ability to revoke access instantly by disabling the key
+#   - Control over key rotation policy
 resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   bucket = aws_s3_bucket.this.id
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = var.kms_key_arn  # null → AWS-managed key; set to CMK ARN in prod
     }
-    bucket_key_enabled = true
+    bucket_key_enabled = true  # Reduces KMS API call cost by ~99% for high-throughput buckets
   }
 }
 
@@ -107,4 +113,15 @@ resource "aws_s3_bucket_policy" "https_only" {
   })
 
   depends_on = [aws_s3_bucket_public_access_block.this]
+}
+
+# S3 server access logging records all requests made to this bucket.
+# Logs are delivered to a separate bucket to avoid recursive logging loops.
+# This satisfies CIS AWS Foundations Benchmark control 3.7.
+resource "aws_s3_bucket_logging" "this" {
+  count = var.logging_bucket_id != null ? 1 : 0
+
+  bucket        = aws_s3_bucket.this.id
+  target_bucket = var.logging_bucket_id
+  target_prefix = "${var.bucket_name}/"
 }

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -34,9 +34,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm     = "aws:kms"
-      kms_master_key_id = var.kms_key_arn  # null → AWS-managed key; set to CMK ARN in prod
+      kms_master_key_id = var.kms_key_arn # null → AWS-managed key; set to CMK ARN in prod
     }
-    bucket_key_enabled = true  # Reduces KMS API call cost by ~99% for high-throughput buckets
+    bucket_key_enabled = true # Reduces KMS API call cost by ~99% for high-throughput buckets
   }
 }
 

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -1,0 +1,81 @@
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+    },
+    var.tags
+  )
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket        = var.bucket_name
+  force_destroy = var.force_destroy
+
+  tags = local.common_tags
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = var.versioning_enabled ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  count  = length(var.lifecycle_rules) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+
+  dynamic "rule" {
+    for_each = var.lifecycle_rules
+    content {
+      id     = rule.value.id
+      status = rule.value.enabled ? "Enabled" : "Disabled"
+
+      dynamic "expiration" {
+        for_each = rule.value.expiration_days != null ? [1] : []
+        content {
+          days = rule.value.expiration_days
+        }
+      }
+
+      dynamic "noncurrent_version_expiration" {
+        for_each = rule.value.noncurrent_version_expiration_days != null ? [1] : []
+        content {
+          noncurrent_days = rule.value.noncurrent_version_expiration_days
+        }
+      }
+
+      dynamic "transition" {
+        for_each = rule.value.transition != null ? rule.value.transition : []
+        content {
+          days          = transition.value.days
+          storage_class = transition.value.storage_class
+        }
+      }
+    }
+  }
+
+  depends_on = [aws_s3_bucket_versioning.this]
+}

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_id" {
+  description = "The name/ID of the S3 bucket"
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket"
+  value       = aws_s3_bucket.this.arn
+}
+
+output "bucket_domain_name" {
+  description = "The bucket domain name"
+  value       = aws_s3_bucket.this.bucket_domain_name
+}
+
+output "bucket_regional_domain_name" {
+  description = "The bucket region-specific domain name"
+  value       = aws_s3_bucket.this.bucket_regional_domain_name
+}

--- a/modules/storage/storage_unit.tftest.hcl
+++ b/modules/storage/storage_unit.tftest.hcl
@@ -45,8 +45,8 @@ run "https_only_policy_applied" {
   }
 
   assert {
-    condition     = aws_s3_bucket_policy.https_only.bucket == "test-bucket-12345"
-    error_message = "HTTPS-only policy must be attached to the bucket."
+    condition     = aws_s3_bucket_policy.https_only != null
+    error_message = "HTTPS-only policy resource must be created."
   }
 }
 

--- a/modules/storage/storage_unit.tftest.hcl
+++ b/modules/storage/storage_unit.tftest.hcl
@@ -37,7 +37,7 @@ run "public_access_is_fully_blocked" {
 # ── Test: HTTPS-only policy is always applied ─────────────────────────────────
 
 run "https_only_policy_applied" {
-  command = plan
+  command = apply
 
   variables {
     bucket_name = "test-bucket-12345"

--- a/modules/storage/storage_unit.tftest.hcl
+++ b/modules/storage/storage_unit.tftest.hcl
@@ -92,7 +92,7 @@ run "encryption_uses_bucket_key" {
   }
 
   assert {
-    condition     = aws_s3_bucket_server_side_encryption_configuration.this.rule[0].bucket_key_enabled == true
+    condition     = one(aws_s3_bucket_server_side_encryption_configuration.this.rule).bucket_key_enabled == true
     error_message = "bucket_key_enabled must be true to reduce KMS API costs."
   }
 }
@@ -107,7 +107,7 @@ run "encryption_uses_provided_kms_key" {
   }
 
   assert {
-    condition     = aws_s3_bucket_server_side_encryption_configuration.this.rule[0].apply_server_side_encryption_by_default[0].kms_master_key_id == "arn:aws:kms:us-west-2:123456789012:key/fake-key-id"
+    condition     = one(aws_s3_bucket_server_side_encryption_configuration.this.rule).apply_server_side_encryption_by_default[0].kms_master_key_id == "arn:aws:kms:us-west-2:123456789012:key/fake-key-id"
     error_message = "Encryption must use the provided KMS key ARN."
   }
 }

--- a/modules/storage/storage_unit.tftest.hcl
+++ b/modules/storage/storage_unit.tftest.hcl
@@ -1,0 +1,167 @@
+# Unit tests for modules/storage
+# Run with: terraform -chdir=modules/storage test
+
+mock_provider "aws" {}
+
+# ── Test: public access is always blocked ─────────────────────────────────────
+
+run "public_access_is_fully_blocked" {
+  command = plan
+
+  variables {
+    bucket_name = "test-bucket-12345"
+    environment = "test"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.this.block_public_acls == true
+    error_message = "block_public_acls must always be true."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.this.block_public_policy == true
+    error_message = "block_public_policy must always be true."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.this.ignore_public_acls == true
+    error_message = "ignore_public_acls must always be true."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.this.restrict_public_buckets == true
+    error_message = "restrict_public_buckets must always be true."
+  }
+}
+
+# ── Test: HTTPS-only policy is always applied ─────────────────────────────────
+
+run "https_only_policy_applied" {
+  command = plan
+
+  variables {
+    bucket_name = "test-bucket-12345"
+    environment = "test"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_policy.https_only.bucket == "test-bucket-12345"
+    error_message = "HTTPS-only policy must be attached to the bucket."
+  }
+}
+
+# ── Test: versioning defaults to enabled ──────────────────────────────────────
+
+run "versioning_enabled_by_default" {
+  command = plan
+
+  variables {
+    bucket_name = "test-bucket-12345"
+    environment = "test"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.this.versioning_configuration[0].status == "Enabled"
+    error_message = "Versioning should be Enabled by default."
+  }
+}
+
+run "versioning_can_be_disabled" {
+  command = plan
+
+  variables {
+    bucket_name        = "test-bucket-12345"
+    environment        = "test"
+    versioning_enabled = false
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.this.versioning_configuration[0].status == "Suspended"
+    error_message = "Setting versioning_enabled = false should set status to Suspended."
+  }
+}
+
+# ── Test: encryption configuration ───────────────────────────────────────────
+
+run "encryption_uses_bucket_key" {
+  command = plan
+
+  variables {
+    bucket_name = "test-bucket-12345"
+    environment = "test"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_server_side_encryption_configuration.this.rule[0].bucket_key_enabled == true
+    error_message = "bucket_key_enabled must be true to reduce KMS API costs."
+  }
+}
+
+run "encryption_uses_provided_kms_key" {
+  command = plan
+
+  variables {
+    bucket_name = "test-bucket-12345"
+    environment = "prod"
+    kms_key_arn = "arn:aws:kms:us-west-2:123456789012:key/fake-key-id"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_server_side_encryption_configuration.this.rule[0].apply_server_side_encryption_by_default[0].kms_master_key_id == "arn:aws:kms:us-west-2:123456789012:key/fake-key-id"
+    error_message = "Encryption must use the provided KMS key ARN."
+  }
+}
+
+# ── Test: force_destroy defaults to false ─────────────────────────────────────
+
+run "force_destroy_off_by_default" {
+  command = plan
+
+  variables {
+    bucket_name = "prod-bucket-12345"
+    environment = "prod"
+  }
+
+  assert {
+    condition     = aws_s3_bucket.this.force_destroy == false
+    error_message = "force_destroy must default to false to protect production data."
+  }
+}
+
+# ── Test: lifecycle configuration ────────────────────────────────────────────
+
+run "no_lifecycle_config_when_rules_empty" {
+  command = plan
+
+  variables {
+    bucket_name     = "test-bucket-12345"
+    environment     = "test"
+    lifecycle_rules = []
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_lifecycle_configuration.this) == 0
+    error_message = "No lifecycle resource should be created when lifecycle_rules is empty."
+  }
+}
+
+run "lifecycle_config_created_when_rules_provided" {
+  command = plan
+
+  variables {
+    bucket_name = "test-bucket-12345"
+    environment = "test"
+    lifecycle_rules = [{
+      id                                 = "test-rule"
+      enabled                            = true
+      expiration_days                    = 90
+      noncurrent_version_expiration_days = 30
+      transition                         = null
+    }]
+  }
+
+  assert {
+    condition     = length(aws_s3_bucket_lifecycle_configuration.this) == 1
+    error_message = "Lifecycle configuration resource should be created when rules are provided."
+  }
+}

--- a/modules/storage/storage_unit.tftest.hcl
+++ b/modules/storage/storage_unit.tftest.hcl
@@ -45,8 +45,13 @@ run "https_only_policy_applied" {
   }
 
   assert {
-    condition     = aws_s3_bucket_policy.https_only != null
-    error_message = "HTTPS-only policy resource must be created."
+    condition     = jsondecode(aws_s3_bucket_policy.https_only.policy).Statement[0].Effect == "Deny"
+    error_message = "HTTPS-only policy must have a Deny effect."
+  }
+
+  assert {
+    condition     = jsondecode(aws_s3_bucket_policy.https_only.policy).Statement[0].Condition.Bool["aws:SecureTransport"] == "false"
+    error_message = "HTTPS-only policy must deny requests where aws:SecureTransport is false."
   }
 }
 

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,0 +1,42 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket (must be globally unique)"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. dev, staging, prod)"
+  type        = string
+}
+
+variable "versioning_enabled" {
+  description = "Enable versioning on the S3 bucket"
+  type        = bool
+  default     = true
+}
+
+variable "force_destroy" {
+  description = "Allow the bucket to be destroyed even when it contains objects"
+  type        = bool
+  default     = false
+}
+
+variable "lifecycle_rules" {
+  description = "List of lifecycle rules for the bucket"
+  type = list(object({
+    id                                 = string
+    enabled                            = bool
+    expiration_days                    = optional(number)
+    noncurrent_version_expiration_days = optional(number)
+    transition = optional(list(object({
+      days          = number
+      storage_class = string
+    })))
+  }))
+  default = []
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -1,27 +1,39 @@
 variable "bucket_name" {
-  description = "Name of the S3 bucket (must be globally unique)"
+  description = "Name of the S3 bucket. Must be globally unique across all AWS accounts and regions."
   type        = string
 }
 
 variable "environment" {
-  description = "Environment name (e.g. dev, staging, prod)"
+  description = "Environment name (e.g. dev, staging, prod)."
   type        = string
 }
 
 variable "versioning_enabled" {
-  description = "Enable versioning on the S3 bucket"
+  description = "Enable object versioning. Required to enable MFA delete and recommended for all buckets containing important data."
   type        = bool
   default     = true
 }
 
 variable "force_destroy" {
-  description = "Allow the bucket to be destroyed even when it contains objects"
+  description = "Allow the bucket to be destroyed even when it contains objects. Set to false in production to prevent accidental data loss."
   type        = bool
   default     = false
 }
 
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key to use for server-side encryption. When null, an AWS-managed key (aws/s3) is used. Providing a CMK is strongly recommended for production — it enables key usage auditing and instant access revocation."
+  type        = string
+  default     = null
+}
+
+variable "logging_bucket_id" {
+  description = "ID (name) of an S3 bucket to receive server access logs. When set, all requests to this bucket are logged to the target bucket under a prefix matching this bucket's name. Leave null to skip access logging."
+  type        = string
+  default     = null
+}
+
 variable "lifecycle_rules" {
-  description = "List of lifecycle rules for the bucket"
+  description = "List of lifecycle rules to automatically transition or expire objects."
   type = list(object({
     id                                 = string
     enabled                            = bool
@@ -36,7 +48,7 @@ variable "lifecycle_rules" {
 }
 
 variable "tags" {
-  description = "Additional tags to apply to the bucket"
+  description = "Additional tags to apply to the bucket."
   type        = map(string)
   default     = {}
 }

--- a/modules/storage/versions.tf
+++ b/modules/storage/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/scripts/setup-backend.sh
+++ b/scripts/setup-backend.sh
@@ -3,7 +3,10 @@
 # Run this ONCE per AWS account before running `terraform init` for the first time.
 #
 # Usage:
-#   AWS_REGION=us-west-2 BUCKET_NAME=my-tf-state-bucket bash scripts/setup-backend.sh
+#   AWS_REGION=us-west-2 \
+#   BUCKET_NAME=my-org-terraform-state \
+#   DYNAMO_TABLE=my-org-terraform-locks \
+#   bash scripts/setup-backend.sh
 
 set -euo pipefail
 
@@ -34,7 +37,7 @@ aws s3api put-bucket-versioning \
   --bucket "${BUCKET}" \
   --versioning-configuration Status=Enabled
 
-echo "==> Enabling server-side encryption on ${BUCKET}"
+echo "==> Enabling KMS server-side encryption on ${BUCKET}"
 aws s3api put-bucket-encryption \
   --bucket "${BUCKET}" \
   --server-side-encryption-configuration '{
@@ -46,11 +49,49 @@ aws s3api put-bucket-encryption \
     }]
   }'
 
-echo "==> Blocking public access on ${BUCKET}"
+echo "==> Blocking all public access on ${BUCKET}"
 aws s3api put-public-access-block \
   --bucket "${BUCKET}" \
   --public-access-block-configuration \
     "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+
+echo "==> Applying HTTPS-only bucket policy on ${BUCKET}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+aws s3api put-bucket-policy \
+  --bucket "${BUCKET}" \
+  --policy "{
+    \"Version\": \"2012-10-17\",
+    \"Statement\": [
+      {
+        \"Sid\": \"DenyNonTLSRequests\",
+        \"Effect\": \"Deny\",
+        \"Principal\": \"*\",
+        \"Action\": \"s3:*\",
+        \"Resource\": [
+          \"arn:aws:s3:::${BUCKET}\",
+          \"arn:aws:s3:::${BUCKET}/*\"
+        ],
+        \"Condition\": {
+          \"Bool\": {
+            \"aws:SecureTransport\": \"false\"
+          }
+        }
+      }
+    ]
+  }"
+
+echo "==> Applying lifecycle rule to expire noncurrent state versions after 90 days"
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket "${BUCKET}" \
+  --lifecycle-configuration '{
+    "Rules": [{
+      "ID": "expire-old-state-versions",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "" },
+      "NoncurrentVersionExpiration": { "NoncurrentDays": 90 },
+      "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 7 }
+    }]
+  }'
 
 echo "==> Creating DynamoDB lock table: ${DYNAMO_TABLE}"
 if aws dynamodb describe-table --table-name "${DYNAMO_TABLE}" --region "${REGION}" 2>/dev/null; then
@@ -62,11 +103,23 @@ else
     --key-schema AttributeName=LockID,KeyType=HASH \
     --billing-mode PAY_PER_REQUEST \
     --region "${REGION}"
-  echo "    Table created."
+
+  echo "    Waiting for table to become ACTIVE..."
+  aws dynamodb wait table-exists \
+    --table-name "${DYNAMO_TABLE}" \
+    --region "${REGION}"
+  echo "    Table ready."
 fi
 
 echo ""
-echo "✅  Backend ready. Update backend.tf files to use:"
-echo "    bucket         = \"${BUCKET}\""
-echo "    dynamodb_table = \"${DYNAMO_TABLE}\""
-echo "    region         = \"${REGION}\""
+echo "Backend ready. Update backend.tf files in each environment directory:"
+echo ""
+echo "  terraform {"
+echo "    backend \"s3\" {"
+echo "      bucket         = \"${BUCKET}\""
+echo "      dynamodb_table = \"${DYNAMO_TABLE}\""
+echo "      region         = \"${REGION}\""
+echo "      encrypt        = true"
+echo "      key            = \"<env>/terraform.tfstate\""
+echo "    }"
+echo "  }"

--- a/scripts/setup-backend.sh
+++ b/scripts/setup-backend.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# setup-backend.sh — Bootstrap the S3 + DynamoDB Terraform remote state backend.
+# Run this ONCE per AWS account before running `terraform init` for the first time.
+#
+# Usage:
+#   AWS_REGION=us-west-2 BUCKET_NAME=my-tf-state-bucket bash scripts/setup-backend.sh
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-west-2}"
+BUCKET="${BUCKET_NAME:-my-terraform-state-bucket-name}"
+DYNAMO_TABLE="${DYNAMO_TABLE:-my-lock-table}"
+
+echo "==> Creating S3 state bucket: ${BUCKET} in ${REGION}"
+
+if aws s3api head-bucket --bucket "${BUCKET}" 2>/dev/null; then
+  echo "    Bucket already exists, skipping creation."
+else
+  if [ "${REGION}" = "us-east-1" ]; then
+    aws s3api create-bucket \
+      --bucket "${BUCKET}" \
+      --region "${REGION}"
+  else
+    aws s3api create-bucket \
+      --bucket "${BUCKET}" \
+      --region "${REGION}" \
+      --create-bucket-configuration LocationConstraint="${REGION}"
+  fi
+  echo "    Bucket created."
+fi
+
+echo "==> Enabling versioning on ${BUCKET}"
+aws s3api put-bucket-versioning \
+  --bucket "${BUCKET}" \
+  --versioning-configuration Status=Enabled
+
+echo "==> Enabling server-side encryption on ${BUCKET}"
+aws s3api put-bucket-encryption \
+  --bucket "${BUCKET}" \
+  --server-side-encryption-configuration '{
+    "Rules": [{
+      "ApplyServerSideEncryptionByDefault": {
+        "SSEAlgorithm": "aws:kms"
+      },
+      "BucketKeyEnabled": true
+    }]
+  }'
+
+echo "==> Blocking public access on ${BUCKET}"
+aws s3api put-public-access-block \
+  --bucket "${BUCKET}" \
+  --public-access-block-configuration \
+    "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+
+echo "==> Creating DynamoDB lock table: ${DYNAMO_TABLE}"
+if aws dynamodb describe-table --table-name "${DYNAMO_TABLE}" --region "${REGION}" 2>/dev/null; then
+  echo "    Table already exists, skipping creation."
+else
+  aws dynamodb create-table \
+    --table-name "${DYNAMO_TABLE}" \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST \
+    --region "${REGION}"
+  echo "    Table created."
+fi
+
+echo ""
+echo "✅  Backend ready. Update backend.tf files to use:"
+echo "    bucket         = \"${BUCKET}\""
+echo "    dynamodb_table = \"${DYNAMO_TABLE}\""
+echo "    region         = \"${REGION}\""

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# setup-branch-protection.sh — Configure branch protection rules on main via GitHub CLI.
+# Run ONCE after creating the repository. Requires gh CLI authenticated with admin scope.
+#
+# Usage:
+#   REPO=theusc6/aws-terraform-infrastructure bash scripts/setup-branch-protection.sh
+#
+# Requirements:
+#   - gh CLI installed and authenticated: gh auth login
+#   - Token must have admin:repo_hook and repo scopes
+
+set -euo pipefail
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+
+echo "==> Configuring branch protection on main for ${REPO}"
+
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/${REPO}/branches/main/protection" \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Module Tests Passed",
+      "Plan (dev)",
+      "Checkov Security Scan (dev)",
+      "TFLint (dev)",
+      "Gitleaks Secret Scan"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": true
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+EOF
+
+echo "==> Branch protection configured on main."
+echo ""
+echo "Required status checks:"
+echo "  - Module Tests Passed"
+echo "  - Plan (dev)"
+echo "  - Checkov Security Scan (dev)"
+echo "  - TFLint (dev)"
+echo "  - Gitleaks Secret Scan"
+echo ""
+echo "Rules applied:"
+echo "  - 1 required approving review"
+echo "  - Code owner review required (CODEOWNERS)"
+echo "  - Dismiss stale reviews on new commits"
+echo "  - Require last push approval (prevents self-approval)"
+echo "  - Linear history (no merge commits)"
+echo "  - No force pushes"
+echo "  - Admins are NOT exempt (enforce_admins: true)"
+echo "  - All conversations must be resolved before merge"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,60 @@
+# Tests
+
+This directory contains [Terraform native tests](https://developer.hashicorp.com/terraform/language/tests)
+(introduced in Terraform 1.6). These tests run directly with `terraform test` — no external
+frameworks required.
+
+## Test strategy
+
+Tests are divided into two categories:
+
+| Category | What it tests | Requires AWS? |
+|----------|---------------|---------------|
+| Unit (mock) | Variable validation, output correctness, resource configuration | No |
+| Integration | Actual AWS API calls, resource creation/destruction | Yes |
+
+The tests in this directory are **unit tests using mock providers**. They validate that:
+- Variable constraints are enforced correctly
+- Resources are configured with expected security properties
+- Outputs are wired to the correct resource attributes
+- Conditional logic (e.g. "only create HTTPS listener when certificate_arn is set") works
+
+Integration tests (which create real AWS resources) are not committed because they require
+live credentials and incur cost. The patterns below serve as templates.
+
+## Running tests
+
+```bash
+# Run all unit tests (no AWS credentials required)
+terraform test
+
+# Run tests for a specific module
+terraform -chdir=modules/kms test
+terraform -chdir=modules/alb test
+terraform -chdir=modules/storage test
+
+# Run a specific test file
+terraform -chdir=modules/kms test -filter=tests/kms_unit.tftest.hcl
+
+# Run with verbose output
+terraform -chdir=modules/kms test -verbose
+```
+
+## Test files
+
+| File | Module | Type |
+|------|--------|------|
+| `kms_unit.tftest.hcl` | `modules/kms` | Unit (mock) |
+| `storage_unit.tftest.hcl` | `modules/storage` | Unit (mock) |
+| `alb_unit.tftest.hcl` | `modules/alb` | Unit (mock) |
+| `networking_unit.tftest.hcl` | `modules/networking/vpc-module` | Unit (mock) |
+
+## Adding new tests
+
+1. Create a `.tftest.hcl` file next to the module's `main.tf` (or in this directory for cross-module tests).
+2. Use `mock_provider "aws"` for unit tests to avoid real API calls.
+3. Use `run` blocks with `command = plan` to validate configuration without applying.
+4. Add `assert` blocks to check specific attribute values and conditions.
+
+See the [Terraform test documentation](https://developer.hashicorp.com/terraform/language/tests)
+for the full syntax reference.


### PR DESCRIPTION
Summary                                                                                              
                                                                                                       
  - Builds out a full AWS demo environment with reusable Terraform modules (ALB, Compute, IAM, KMS,
  Monitoring, Networking/SGs) across dev, staging, and prod environments                               
  - Hardens all modules to production standard: fixes critical bugs, adds input validation, security
  group rules, encryption defaults, and tagging consistency
  - Adds a reusable CI/CD pipeline (terraform-deploy.yml) with plan-before-apply enforcement,
  concurrency guards, least-privilege permissions, and drift detection via scheduled workflow
  - Integrates Infracost for cost estimation on PRs and native terraform test unit tests wired into CI
  - Adds full documentation suite: per-module READMEs, CONTRIBUTING guide, CHANGELOG, PR template,
  CODEOWNERS, and a Makefile for local dev workflows

  Test plan

  - make fmt && make validate passes locally
  - make test runs native Terraform unit tests (ALB, KMS) successfully
  - make plan ENV=dev produces expected plan against dev workspace
  - CI workflows trigger correctly on PR (plan, cost estimate, module tests)
  - Drift detection workflow runs on schedule without false positives
  - Prod environment requires manual approval before apply

----

This PR builds a classic 3-tier web application infrastructure on AWS — no actual application code, just  
  the infra to host one. Specifically:                                                                 
                                                                                                       
  - VPC — public/private subnets across 2 AZs, NAT gateway, VPC flow logs, S3 gateway endpoint         
  - ALB — internet-facing Application Load Balancer in public subnets, health checks on /health        
  - EC2 Auto Scaling Group — app servers in private subnets (only reachable from ALB), Amazon Linux    
  2023, SSM access instead of SSH
  - KMS — customer-managed key for EBS + S3 encryption                                                 
  - S3 — versioned app storage bucket + separate access logs bucket
  - IAM — EC2 instance role with SSM + CloudWatch agent permissions
  - Monitoring — CloudWatch alarms on the ASG and ALB

This is a demo/reference architecture.