### PR TITLE
chore: disable drift detection until AWS credentials are configured

### DIFF
--- a/.github/workflows/drift-detection.yml
+++ b/.github/workflows/drift-detection.yml
@@ -44,10 +44,7 @@ jobs:
   drift-dev:
     name: Drift Check — dev
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.environment == 'all' ||
-      github.event.inputs.environment == 'dev'
+    if: false # Disabled until AWS credentials are configured — remove this line to enable
     permissions:
       contents: read
       id-token: write
@@ -129,10 +126,7 @@ jobs:
   drift-staging:
     name: Drift Check — staging
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.environment == 'all' ||
-      github.event.inputs.environment == 'staging'
+    if: false # Disabled until AWS credentials are configured — remove this line to enable
     permissions:
       contents: read
       id-token: write
@@ -209,10 +203,7 @@ jobs:
   drift-prod:
     name: Drift Check — prod
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.environment == 'all' ||
-      github.event.inputs.environment == 'prod'
+    if: false # Disabled until AWS credentials are configured — remove this line to enable
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Adds `if: false` to all three drift check jobs (dev, staging, prod)
- Workflow stays intact with schedule and dispatch triggers for future use
- Jobs will show as skipped instead of failing
- To re-enable: remove the `if: false` line from each job

🤖 Generated with [Claude Code](https://claude.com/claude-code)